### PR TITLE
Improves handling of parse errors

### DIFF
--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -13,6 +13,7 @@ dtrace-parser = { path = "../dtrace-parser", version = "0.1.8" }
 proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
+quote = "1.0.9"
 usdt-impl = { path = "../usdt-impl", version = "0.1.5" }
 
 [lib]


### PR DESCRIPTION
- Adds a concrete error type used to represent errors while parsing the
D provider file using Pest.
- Adds a slightly better error message when including unsupported data
types, and handles/unpacks that in the procedural macro. Compile-time
messages now show a span around the offending D source file, and provide
a hint to check the types.