### PR TITLE
simplify use of probes with zero arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"probe-test-macro",
 	"tests/empty",
 	"tests/namespace-conflict",
+	"tests/zero-arg-probe",
 	"usdt",
 	"usdt-impl",
 	"usdt-macro"
@@ -15,6 +16,7 @@ default-members = [
 	"dtrace-parser",
 	"tests/empty",
 	"tests/namespace-conflict",
+	"tests/zero-arg-probe",
 	"usdt",
 	"usdt-impl",
 	"usdt-macro"

--- a/tests/empty/provider.d
+++ b/tests/empty/provider.d
@@ -1,5 +1,6 @@
 provider stuff {
 	probe start(uint8_t);
 	probe stop(char*, uint8_t);
+	probe noargs();
 	probe unused();
 };

--- a/tests/zero-arg-probe/Cargo.toml
+++ b/tests/zero-arg-probe/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zero-arg-probe"
+version = "0.1.0"
+authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
+           "Adam H. Leventhal <ahl@oxidecomputer.com>"]
+edition = "2018"
+
+[dependencies]
+usdt = { path = "../../usdt" }
+
+[build-dependencies]
+usdt = { path = "../../usdt" }

--- a/tests/zero-arg-probe/build.rs
+++ b/tests/zero-arg-probe/build.rs
@@ -1,0 +1,5 @@
+use usdt::Builder;
+
+fn main() {
+    Builder::new("test.d").build().unwrap();
+}

--- a/tests/zero-arg-probe/src/main.rs
+++ b/tests/zero-arg-probe/src/main.rs
@@ -3,16 +3,13 @@
 
 use usdt::register_probes;
 
-include!(concat!(env!("OUT_DIR"), "/provider.rs"));
+include!(concat!(env!("OUT_DIR"), "/test.rs"));
 
 fn main() {
     register_probes().unwrap();
 
-    let counter: u8 = 0;
-    stuff_start!(|| (counter));
-    stuff_stop!(|| ("the probe has fired", counter));
-    stuff_noargs!(|| ());
-    stuff_noargs!();
+    test_here__i__am!(|| ());
+    test_here__i__am!();
 }
 
 #[cfg(test)]

--- a/tests/zero-arg-probe/test.d
+++ b/tests/zero-arg-probe/test.d
@@ -1,0 +1,3 @@
+provider test {
+	probe here__i__am();
+};

--- a/usdt-impl/src/empty.rs
+++ b/usdt-impl/src/empty.rs
@@ -43,7 +43,7 @@ fn compile_probe(
 ) -> TokenStream {
     let macro_name = crate::format_probe(&config.format, provider_name, probe.name());
     // If there are no arguments we allow the user to optionally omit the closure.
-    let no_args = if probe.types().is_empty() {
+    let no_args_match = if probe.types().is_empty() {
         quote! { () => { #macro_name!(|| ()) }; }
     } else {
         quote! {}
@@ -51,7 +51,7 @@ fn compile_probe(
     quote! {
         #[allow(unused)]
         macro_rules! #macro_name {
-            #no_args
+            #no_args_match
             ($args_lambda:expr) => {
                 let _ = || ($args_lambda);
             };

--- a/usdt-impl/src/empty.rs
+++ b/usdt-impl/src/empty.rs
@@ -42,9 +42,16 @@ fn compile_probe(
     config: &crate::CompileProvidersConfig,
 ) -> TokenStream {
     let macro_name = crate::format_probe(&config.format, provider_name, probe.name());
+    // If there are no arguments we allow the user to optionally omit the closure.
+    let no_args = if probe.types().is_empty() {
+        quote! { () => { #macro_name!(|| ()) }; }
+    } else {
+        quote! {}
+    };
     quote! {
         #[allow(unused)]
         macro_rules! #macro_name {
+            #no_args
             ($args_lambda:expr) => {
                 let _ = || ($args_lambda);
             };

--- a/usdt-impl/src/linker.rs
+++ b/usdt-impl/src/linker.rs
@@ -163,11 +163,18 @@ fn compile_probe(
         })
         .collect::<Vec<_>>();
 
-    // Handle a single return value from the closure
-    let singleton_fix = if types.len() == 1 {
-        quote! {
-            let args = (args,);
-        }
+    let preamble = match types.len() {
+        // Don't bother with arguments if there are none.
+        0 => quote! { $args_lambda(); },
+        // Wrap a single argument in a tuple.
+        1 => quote! { let args = ($args_lambda(),); },
+        // General case.
+        _ => quote! { let args = $args_lambda(); },
+    };
+
+    // If there are no arguments we allow the user to optionally omit the closure.
+    let no_args = if types.is_empty() {
+        quote! { () => { #macro_name!(|| ()) }; }
     } else {
         quote! {}
     };
@@ -190,6 +197,7 @@ fn compile_probe(
 
         #[allow(unused)]
         macro_rules! #macro_name {
+            #no_args
             ($args_lambda:expr) => {
                 // NOTE: This block defines an internal empty function and then a lambda which
                 // calls it. This is all strictly for type-checking, and is optimized out. It is
@@ -198,15 +206,15 @@ fn compile_probe(
                 {
                     fn _type_check(#(#type_check_args),*) { }
                     let _ = || {
-                        let args = $args_lambda();
-                        #singleton_fix
+                        #preamble
                         _type_check(#(#expanded_lambda_args),*);
                     };
                 }
                 unsafe {
                     if $crate::#mod_name::#is_enabled_fn() != 0 {
-                        let args = $args_lambda();
-                        #singleton_fix
+                        // Get the input arguments
+                        #preamble
+                        // Marshal the arguments.
                         #(#args)*
                         asm!(
                             ".reference {typedefs}",
@@ -219,7 +227,7 @@ fn compile_probe(
                         );
                     }
                 }
-            }
+            };
         }
     }
 }

--- a/usdt-impl/src/linker.rs
+++ b/usdt-impl/src/linker.rs
@@ -173,7 +173,7 @@ fn compile_probe(
     };
 
     // If there are no arguments we allow the user to optionally omit the closure.
-    let no_args = if types.is_empty() {
+    let no_args_match = if types.is_empty() {
         quote! { () => { #macro_name!(|| ()) }; }
     } else {
         quote! {}
@@ -197,7 +197,7 @@ fn compile_probe(
 
         #[allow(unused)]
         macro_rules! #macro_name {
-            #no_args
+            #no_args_match
             ($args_lambda:expr) => {
                 // NOTE: This block defines an internal empty function and then a lambda which
                 // calls it. This is all strictly for type-checking, and is optimized out. It is

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -90,10 +90,18 @@ fn compile_probe(
         })
         .collect::<Vec<_>>();
 
-    let singleton_fix = if probe.types().len() == 1 {
-        quote! {
-            let args = (args,);
-        }
+    let preamble = match types.len() {
+        // Don't bother with arguments if there are none.
+        0 => quote! { $args_lambda(); },
+        // Wrap a single argument in a tuple.
+        1 => quote! { let args = ($args_lambda(),); },
+        // General case.
+        _ => quote! { let args = $args_lambda(); },
+    };
+
+    // If there are no arguments we allow the user to optionally omit the closure.
+    let no_args = if types.is_empty() {
+        quote! { () => { #macro_name!(|| ()) }; }
     } else {
         quote! {}
     };
@@ -104,6 +112,7 @@ fn compile_probe(
     let out = quote! {
         #[allow(unused)]
         macro_rules! #macro_name {
+            #no_args
             ($args_lambda:expr) => {
                 // NOTE: This block defines an internal empty function and then a lambda which
                 // calls it. This is all strictly for type-checking, and is optimized out. It is
@@ -112,8 +121,7 @@ fn compile_probe(
                 {
                     fn _type_check(#(#type_check_args),*) { }
                     let _ = || {
-                        let args = $args_lambda();
-                        #singleton_fix
+                        #preamble
                         _type_check(#(#expanded_lambda_args),*);
                     };
                 }
@@ -130,10 +138,8 @@ fn compile_probe(
                 }
 
                 if is_enabled != 0 {
-                    // Compute the arguments.
-                    let args = $args_lambda();
-                    // Convert an item to a singleton tuple.
-                    #singleton_fix
+                    // Get the input arguments
+                    #preamble
                     // Marshal the arguments.
                     #(#args)*
                     unsafe {

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -100,7 +100,7 @@ fn compile_probe(
     };
 
     // If there are no arguments we allow the user to optionally omit the closure.
-    let no_args = if types.is_empty() {
+    let no_args_match = if types.is_empty() {
         quote! { () => { #macro_name!(|| ()) }; }
     } else {
         quote! {}
@@ -112,7 +112,7 @@ fn compile_probe(
     let out = quote! {
         #[allow(unused)]
         macro_rules! #macro_name {
-            #no_args
+            #no_args_match
             ($args_lambda:expr) => {
                 // NOTE: This block defines an internal empty function and then a lambda which
                 // calls it. This is all strictly for type-checking, and is optimized out. It is


### PR DESCRIPTION
This allows a probe with zero arguments to be invoked without a closure (optionally).