### PR TITLE
Fixes racy use of tempfiles when calling out to DTrace

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
           toolchain: nightly
           override: true
           profile: minimal
-      - run: cargo check --release
+      - run: RUST_BACKTRACE=1 cargo check --release --verbose
 
   build-and-test:
     name: Build and test entire `usdt` project
@@ -43,4 +43,4 @@ jobs:
           toolchain: nightly
           override: true
           profile: minimal
-      - run: cargo test --release --no-fail-fast
+      - run: RUST_BACKTRACE=1 cargo test --release --no-fail-fast --verbose

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -47,6 +47,9 @@ pub enum Error {
     /// An error occurred extracting probe information from the encoded object file sections
     #[error("The file is not a valid object file")]
     InvalidFile,
+    /// Error related to calling out to DTrace itself
+    #[error("Failed to call DTrace subprocess")]
+    DTraceError,
 }
 
 #[derive(Default, Debug, Deserialize)]


### PR DESCRIPTION
In the linker version of this crate, we rely on `dtrace(1)` to generate
a header file, and then parse that to construct the probe macros. The
previous implementation used temporary files to cache the provider and
the generated header, passing those to `dtrace(1)` in the `-s` and `-o`
flags. These files are in a temporary directory, but they have the same
name, so if the temp-dir is the same, that file will be overwritten if
there are concurrent builds. One situation in which that is actually
pretty likely to happen is testing. One test will may see a corrupt
provider or header output file, and thus fail in odd and confusing ways.

This commit addresses this by using stdin/stdout to communicate the
provider and header files with the `dtrace(1)` subprocess.

It also makes testing on CI verbose and include tracebacks, to help
diagnose further failures.