### PR TITLE
Adds no-linker feature for building on macos without relying on the

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest ]
+        features: [ "", "--features no-linker" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -43,4 +44,4 @@ jobs:
           toolchain: nightly
           override: true
           profile: minimal
-      - run: RUST_BACKTRACE=1 cargo test --release --no-fail-fast --verbose
+      - run: RUST_BACKTRACE=1 cargo test --release --no-fail-fast ${{ matrix.features }} --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,10 @@ jobs:
   linux-check:
     name: Basic check that `usdt` compiles without issue on Linux
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        asm-feature: [ "", "--features asm" ]
+        no-linker-feature: [ "", "--features no-linker" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -28,7 +32,14 @@ jobs:
           toolchain: nightly
           override: true
           profile: minimal
-      - run: RUST_BACKTRACE=1 cargo check --release --verbose
+      - run: >
+          RUST_BACKTRACE=1
+          cargo check
+          --release
+          --verbose
+          --workspace
+          ${{ matrix.asm-feature }}
+          ${{ matrix.no-linker-feature }}
 
   build-and-test:
     name: Build and test entire `usdt` project
@@ -36,7 +47,8 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest ]
-        features: [ "", "--features no-linker" ]
+        asm-feature: [ "", "--features asm" ]
+        no-linker-feature: [ "", "--features no-linker" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -44,4 +56,12 @@ jobs:
           toolchain: nightly
           override: true
           profile: minimal
-      - run: RUST_BACKTRACE=1 cargo test --release --no-fail-fast ${{ matrix.features }} --verbose
+      - run: >
+          RUST_BACKTRACE=1
+          cargo test
+          --release
+          --no-fail-fast
+          --verbose
+          --workspace
+          ${{ matrix.asm-feature }}
+          ${{ matrix.no-linker-feature }}

--- a/probe-test-macro/Cargo.toml
+++ b/probe-test-macro/Cargo.toml
@@ -10,3 +10,4 @@ usdt = { path = "../usdt" }
 
 [features]
 asm = ["usdt/asm"]
+no-linker = ["usdt/no-linker"]

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -17,8 +17,9 @@ libc = "0.2.88"
 proc-macro2 = "1.0.24"
 quote = "1.0.9"
 serde = { version = "1.0.124", features = ["derive"] }
-syn = { version = "1.0.60", optional = true}
+syn = "1.0.60"
 thiserror = "1.0.24"
 
 [features]
-asm = ["syn"]
+asm = []
+no-linker = []

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -1,0 +1,173 @@
+//! Shared code used in both the linker and no-linker implementations of this crate.
+// Copyright 2021 Oxide Computer Company
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+// Construct function call that is used internally in the UDST-generated macros, to allow
+// compile-time type checking of the lambda arguments.
+pub fn generate_type_check(types: &[dtrace_parser::DataType]) -> TokenStream {
+    let type_check_args = types
+        .iter()
+        .map(|typ| {
+            let arg = syn::parse_str::<syn::FnArg>(&format!("_: {}", typ.to_rust_type())).unwrap();
+            quote! { #arg }
+        })
+        .collect::<Vec<_>>();
+    let expanded_lambda_args = (0..types.len())
+        .map(|i| {
+            let index = syn::Index::from(i);
+            quote! { args.#index }
+        })
+        .collect::<Vec<_>>();
+
+    let preamble = unpack_argument_lambda(&types);
+
+    // NOTE: This block defines an internal empty function and then a lambda which
+    // calls it. This is all strictly for type-checking, and is optimized out. It is
+    // defined in a scope to avoid multiple-definition errors in the scope of the macro
+    // expansion site.
+    quote! {
+        {
+            fn _type_check(#(#type_check_args),*) { }
+            let _ = || {
+                #preamble
+                _type_check(#(#expanded_lambda_args),*);
+            };
+        }
+    }
+}
+
+// Return code to destructure a probe arguments into identifiers, and to pass those to ASM
+// registers.
+pub fn construct_probe_args(types: &[dtrace_parser::DataType]) -> (TokenStream, TokenStream) {
+    // TODO this will fail with more than 6 parameters.
+    let abi_regs = ["rdi", "rsi", "rdx", "rcx", "r8", "r9"];
+    assert!(
+        types.len() <= abi_regs.len(),
+        "Up to 6 probe arguments are currently supported"
+    );
+    let (unpacked_args, in_regs): (Vec<_>, Vec<_>) = types
+        .iter()
+        .zip(&abi_regs)
+        .enumerate()
+        .map(|(i, (typ, reg))| {
+            let arg = format_ident!("arg_{}", i);
+            let index = syn::Index::from(i);
+            let input = quote! { args.#index };
+            let value = asm_type_convert(typ, input);
+            let destructured_arg = quote! {
+                let #arg = #value;
+            };
+            let register_arg = quote! { in(#reg) #arg };
+            (destructured_arg, register_arg)
+        })
+        .unzip();
+    let preamble = unpack_argument_lambda(&types);
+    let unpacked_args = quote! {
+        #preamble
+        #(#unpacked_args)*
+    };
+    let in_regs = quote! { #(#in_regs,)* };
+    (unpacked_args, in_regs)
+}
+
+fn unpack_argument_lambda(types: &[dtrace_parser::DataType]) -> TokenStream {
+    match types.len() {
+        // Don't bother with arguments if there are none.
+        0 => quote! { $args_lambda(); },
+        // Wrap a single argument in a tuple.
+        1 => quote! { let args = ($args_lambda(),); },
+        // General case.
+        _ => quote! { let args = $args_lambda(); },
+    }
+}
+
+// Convert a supported data type to one passed to the probe function in a register
+fn asm_type_convert(typ: &dtrace_parser::DataType, input: TokenStream) -> TokenStream {
+    match typ {
+        dtrace_parser::DataType::String => quote! {
+            ([#input.as_bytes(), &[0_u8]].concat().as_ptr() as i64)
+        },
+        _ => quote! { (#input as i64) },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_generate_type_check() {
+        let types = &[dtrace_parser::DataType::U8, dtrace_parser::DataType::String];
+        let block = generate_type_check(types);
+        let s = block.to_string();
+        let fn_start = s.find('f').unwrap();
+        let fn_body = s.find("{ }").unwrap();
+        let should_be_fn = &s[fn_start..fn_body + 3];
+        let type_check_fn = syn::parse_str::<syn::ItemFn>(should_be_fn)
+            .expect("Could not parse out type-check function signature");
+        let expected = syn::parse_str::<syn::ItemFn>("fn _type_check(_: u8, _: &str) { }").unwrap();
+        assert_eq!(type_check_fn, expected);
+
+        let call_start = s[fn_body..].find("_type_check").unwrap();
+        let call_end = s.rfind("; } ; }").unwrap();
+        let should_be_call = &s[fn_body + call_start..call_end];
+        let call_fn = syn::parse_str::<syn::ExprCall>(should_be_call)
+            .expect("Could not parse out call to type-check function");
+        let expected = syn::parse_str::<syn::ExprCall>("_type_check(args.0, args.1)").unwrap();
+        assert_eq!(call_fn, expected);
+    }
+
+    #[test]
+    fn test_construct_probe_args() {
+        let types = &[dtrace_parser::DataType::U8, dtrace_parser::DataType::String];
+        let registers = &["rdi", "rsi"];
+        let (args, regs) = construct_probe_args(types);
+        for (i, arg) in args
+            .to_string()
+            .split(';')
+            .skip(1)
+            .take(types.len())
+            .enumerate()
+        {
+            let arg = arg.replace(" ", "");
+            let expected = format!("letarg_{}=({}args.{}", i, if i > 0 { "[" } else { "" }, i);
+            println!("{}\n\n{}", arg, expected);
+            assert!(arg.starts_with(&expected));
+        }
+
+        for (i, (expected, actual)) in registers
+            .iter()
+            .zip(regs.to_string().split(','))
+            .enumerate()
+        {
+            let reg = actual.replace(" ", "");
+            let expected = format!("in(\"{}\")arg_{}", expected, i);
+            assert_eq!(reg, expected);
+        }
+    }
+
+    #[test]
+    fn test_asm_type_convert() {
+        use std::str::FromStr;
+        let out = asm_type_convert(
+            &dtrace_parser::DataType::U8,
+            TokenStream::from_str("foo").unwrap(),
+        );
+        let out = syn::parse_str::<syn::Expr>(&out.to_string()).unwrap();
+        let expected = syn::parse_str::<syn::Expr>("(foo as i64)").unwrap();
+        assert_eq!(out, expected);
+
+        let out = asm_type_convert(
+            &dtrace_parser::DataType::String,
+            TokenStream::from_str("foo").unwrap(),
+        );
+        let out = syn::parse_str::<syn::Expr>(&out.to_string()).unwrap();
+        let expected =
+            syn::parse_str::<syn::Expr>("([foo.as_bytes(), &[0_u8]].concat().as_ptr() as i64)")
+                .unwrap();
+        assert_eq!(out, expected);
+    }
+}

--- a/usdt-impl/src/empty.rs
+++ b/usdt-impl/src/empty.rs
@@ -3,6 +3,8 @@ use std::convert::TryFrom;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
+use crate::common;
+
 pub fn compile_providers(
     source: &str,
     config: &crate::CompileProvidersConfig,
@@ -41,22 +43,15 @@ fn compile_probe(
     provider_name: &str,
     config: &crate::CompileProvidersConfig,
 ) -> TokenStream {
-    let macro_name = crate::format_probe(&config.format, provider_name, probe.name());
-    // If there are no arguments we allow the user to optionally omit the closure.
-    let no_args_match = if probe.types().is_empty() {
-        quote! { () => { #macro_name!(|| ()) }; }
-    } else {
-        quote! {}
-    };
-    quote! {
-        #[allow(unused)]
-        macro_rules! #macro_name {
-            #no_args_match
-            ($args_lambda:expr) => {
-                let _ = || ($args_lambda);
-            };
-        }
-    }
+    let impl_block = quote! { let _ = || ($args_lambda); };
+    common::build_probe_macro(
+        config,
+        provider_name,
+        probe.name(),
+        probe.types(),
+        quote! {},
+        impl_block,
+    )
 }
 
 pub fn register_probes() -> Result<(), crate::Error> {

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -3,17 +3,21 @@ use thiserror::Error;
 
 pub mod record;
 
-#[cfg(feature = "asm")]
-#[cfg_attr(target_os = "linux", path = "empty.rs")]
-#[cfg_attr(target_os = "macos", path = "linker.rs")]
-#[cfg_attr(
-    all(not(target_os = "macos"), not(target_os = "linux")),
-    path = "no-linker.rs"
-)]
-mod internal;
+#[cfg_attr(any(target_os = "linux", not(feature = "asm")), allow(dead_code))]
+mod common;
 
-#[cfg(not(feature = "asm"))]
-#[cfg_attr(not(feature = "asm"), path = "empty.rs")]
+#[cfg_attr(any(target_os = "linux", not(feature = "asm")), path = "empty.rs")]
+#[cfg_attr(not(target_os = "macos"), path = "no-linker.rs")]
+#[cfg_attr(
+    all(target_os = "macos", feature = "no-linker"),
+    path = "no-linker.rs",
+    allow(unused_attributes)
+)]
+#[cfg_attr(
+    all(target_os = "macos", not(feature = "no-linker")),
+    path = "linker.rs",
+    allow(unused_attributes)
+)]
 mod internal;
 
 /// Register an application's probe points with DTrace.

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -4,6 +4,7 @@ use dof::{serialize_section, Section};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
+use crate::common;
 use crate::record::{parse_probe_records, PROBE_REC_VERSION};
 
 /// Compile a DTrace provider definition into Rust tokens that implement its probes.
@@ -46,58 +47,10 @@ fn compile_probe(
     config: &crate::CompileProvidersConfig,
 ) -> TokenStream {
     let macro_name = crate::format_probe(&config.format, provider, probe.name());
-    // TODO this will fail with more than 6 parameters.
-    let abi_regs = ["rdi", "rsi", "rdx", "rcx", "r8", "r9"];
-    let in_regs = abi_regs
-        .iter()
-        .take(probe.types().len())
-        .enumerate()
-        .map(|(i, reg)| {
-            let arg = quote::format_ident!("arg_{}", i);
-            quote! { in(#reg) #arg }
-        })
-        .collect::<Vec<_>>();
-
-    // Construct arguments to a unused closure declared to check the arguments to the generated
-    // probe macro itself.
-    let type_check_args = probe
-        .types()
-        .iter()
-        .map(|typ| {
-            let arg = syn::parse_str::<syn::FnArg>(&format!("_: {}", typ.to_rust_type())).unwrap();
-            quote! { #arg }
-        })
-        .collect::<Vec<_>>();
-    let expanded_lambda_args = (0..probe.types().len())
-        .map(|i| {
-            let index = syn::Index::from(i);
-            quote! { args.#index }
-        })
-        .collect::<Vec<_>>();
-
-    let args = probe
-        .types()
-        .iter()
-        .enumerate()
-        .map(|(i, typ)| {
-            let arg = quote::format_ident!("arg_{}", i);
-            let index = syn::Index::from(i);
-            let input = quote! { args . #index };
-            let value = asm_type_convert(typ, input);
-            quote! {
-                let #arg = #value;
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let preamble = match probe.types().len() {
-        // Don't bother with arguments if there are none.
-        0 => quote! { $args_lambda(); },
-        // Wrap a single argument in a tuple.
-        1 => quote! { let args = ($args_lambda(),); },
-        // General case.
-        _ => quote! { let args = $args_lambda(); },
-    };
+    let type_check_block = common::generate_type_check(probe.types());
+    let (unpacked_args, in_regs) = common::construct_probe_args(probe.types());
+    let is_enabled_rec = asm_rec(provider, probe.name(), None);
+    let probe_rec = asm_rec(provider, probe.name(), Some(probe.types()));
 
     // If there are no arguments we allow the user to optionally omit the closure.
     let no_args_match = if probe.types().is_empty() {
@@ -106,26 +59,12 @@ fn compile_probe(
         quote! {}
     };
 
-    let is_enabled_rec = asm_rec(provider, probe.name(), None);
-    let probe_rec = asm_rec(provider, probe.name(), Some(probe.types()));
-
     let out = quote! {
         #[allow(unused)]
         macro_rules! #macro_name {
             #no_args_match
             ($args_lambda:expr) => {
-                // NOTE: This block defines an internal empty function and then a lambda which
-                // calls it. This is all strictly for type-checking, and is optimized out. It is
-                // defined in a scope to avoid multiple-definition errors in the scope of the macro
-                // expansion site.
-                {
-                    fn _type_check(#(#type_check_args),*) { }
-                    let _ = || {
-                        #preamble
-                        _type_check(#(#expanded_lambda_args),*);
-                    };
-                }
-
+                #type_check_block
                 let mut is_enabled: u64;
                 // TODO can this block be option(pure)?
                 unsafe {
@@ -138,16 +77,14 @@ fn compile_probe(
                 }
 
                 if is_enabled != 0 {
-                    // Get the input arguments
-                    #preamble
-                    // Marshal the arguments.
-                    #(#args)*
+                    #unpacked_args
                     unsafe {
                         asm!(
                             "990:   nop",
                             #probe_rec,
-                            #(#in_regs,)*
-                            options(nomem, nostack, preserves_flags));
+                            #in_regs
+                            options(nomem, nostack, preserves_flags)
+                        );
                     }
                 }
             };
@@ -159,9 +96,17 @@ fn compile_probe(
 
 fn extract_probe_records_from_section() -> Result<Option<Section>, crate::Error> {
     extern "C" {
-        #[link_name = "__start_set_dtrace_probes"]
+        #[cfg_attr(
+            target_os = "macos",
+            link_name = "\x01section$start$__DATA$__dtrace_probes"
+        )]
+        #[cfg_attr(not(target_os = "macos"), link_name = "__start_set_dtrace_probes")]
         static dtrace_probes_start: usize;
-        #[link_name = "__stop_set_dtrace_probes"]
+        #[cfg_attr(
+            target_os = "macos",
+            link_name = "\x01section$end$__DATA$__dtrace_probes"
+        )]
+        #[cfg_attr(not(target_os = "macos"), link_name = "__stop_set_dtrace_probes")]
         static dtrace_probes_stop: usize;
     }
 
@@ -181,7 +126,12 @@ fn extract_probe_records_from_section() -> Result<Option<Section>, crate::Error>
 }
 
 // Construct the ASM record for a probe. If `types` is `None`, then is is an is-enabled probe.
-fn asm_rec(prov: &str, probe: &str, types: Option<&Vec<dtrace_parser::DataType>>) -> String {
+fn asm_rec(prov: &str, probe: &str, types: Option<&[dtrace_parser::DataType]>) -> String {
+    let section_ident = if cfg!(target_os = "macos") {
+        r#"__DATA,__dtrace_probes,regular,no_dead_strip"#
+    } else {
+        r#"set_dtrace_probes,"a","progbits""#
+    };
     let is_enabled = types.is_none();
     let n_args = types.map_or(0, |typ| typ.len());
     let arguments = types.map_or_else(String::new, |types| {
@@ -193,7 +143,7 @@ fn asm_rec(prov: &str, probe: &str, types: Option<&Vec<dtrace_parser::DataType>>
     });
     format!(
         r#"
-                    .pushsection set_dtrace_probes,"a","progbits"
+                    .pushsection {section_ident}
                     .balign 8
             991:
                     .4byte 992f-991b    // length
@@ -207,6 +157,7 @@ fn asm_rec(prov: &str, probe: &str, types: Option<&Vec<dtrace_parser::DataType>>
                     .balign 8
             992:    .popsection
         "#,
+        section_ident = section_ident,
         version = PROBE_REC_VERSION,
         n_args = n_args,
         flags = if is_enabled { 1 } else { 0 },
@@ -216,26 +167,33 @@ fn asm_rec(prov: &str, probe: &str, types: Option<&Vec<dtrace_parser::DataType>>
     )
 }
 
-fn asm_type_convert(typ: &dtrace_parser::DataType, input: TokenStream) -> TokenStream {
-    match typ {
-        dtrace_parser::DataType::String => quote! {
-            ([#input.as_bytes(), &[0_u8]].concat().as_ptr() as i64)
-        },
-        _ => quote! { (#input as i64) },
-    }
-}
-
 pub fn register_probes() -> Result<(), crate::Error> {
-    if let Some(ref section) = extract_probe_records_from_section().map_err(crate::Error::from)? {
-        ioctl_section(&serialize_section(&section)).map_err(crate::Error::from)
+    if let Some(ref section) = extract_probe_records_from_section()? {
+        let module_name = section
+            .providers
+            .values()
+            .next()
+            .and_then(|provider| {
+                provider.probes.values().next().and_then(|probe| {
+                    crate::record::addr_to_info(probe.address)
+                        .1
+                        .map(|path| path.rsplit('/').next().map(String::from).unwrap_or(path))
+                        .or_else(|| Some(format!("?{:#x}", probe.address)))
+                })
+            })
+            .unwrap_or_else(|| String::from("unknown-module"));
+        let mut modname = [0; 64];
+        for (i, byte) in module_name.bytes().take(modname.len() - 1).enumerate() {
+            modname[i] = byte as i8;
+        }
+        ioctl_section(&serialize_section(&section), modname).map_err(crate::Error::from)
     } else {
         Ok(())
     }
 }
 
-fn ioctl_section(buf: &[u8]) -> Result<(), std::io::Error> {
-    let mut modname = [0 as ::std::os::raw::c_char; 64];
-    modname[0] = 'a' as i8;
+#[cfg(not(target_os = "macos"))]
+fn ioctl_section(buf: &[u8], modname: [std::os::raw::c_char; 64]) -> Result<(), std::io::Error> {
     let helper = dof::dof_bindings::dof_helper {
         dofhp_mod: modname,
         dofhp_addr: buf.as_ptr() as u64,
@@ -252,5 +210,62 @@ fn ioctl_section(buf: &[u8]) -> Result<(), std::io::Error> {
         Ok(())
     } else {
         Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn ioctl_section(buf: &[u8], modname: [std::os::raw::c_char; 64]) -> Result<(), std::io::Error> {
+    let helper = dof::dof_bindings::dof_ioctl_data {
+        dofiod_count: 1,
+        dofiod_helpers: [dof::dof_bindings::dof_helper {
+            dofhp_mod: modname,
+            dofhp_addr: buf.as_ptr() as u64,
+            dofhp_dof: buf.as_ptr() as u64,
+        }],
+    };
+    let data = &(&helper) as *const _;
+    let cmd: u64 = 0x80086804;
+    let ret = unsafe {
+        let file = CString::new("/dev/dtracehelper".as_bytes()).unwrap();
+        let fd = libc::open(file.as_ptr(), libc::O_RDWR);
+        libc::ioctl(fd, cmd, data)
+    };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_asm_rec() {
+        let provider = "provider";
+        let probe = "probe";
+        let types = [dtrace_parser::DataType::U8, dtrace_parser::DataType::String];
+        let record = asm_rec(provider, probe, Some(&types));
+        let mut lines = record.lines();
+        println!("{}", record);
+        lines.next(); // empty line
+        assert!(lines.next().unwrap().find(".pushsection").is_some());
+        let mut lines = lines.skip(3);
+        assert!(lines
+            .next()
+            .unwrap()
+            .find(&format!(".byte {}", PROBE_REC_VERSION))
+            .is_some());
+        assert!(lines
+            .next()
+            .unwrap()
+            .find(&format!(".byte {}", types.len()))
+            .is_some());
+        for (typ, line) in types.iter().zip(lines.skip(4)) {
+            assert!(line
+                .find(&format!(".asciz \"{}\"", typ.to_c_type()))
+                .is_some());
+        }
     }
 }

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -14,7 +14,7 @@ proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
-usdt-impl = { path = "../usdt-impl", version = "0.1.5" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.6" }
 
 [lib]
 proc-macro = true

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -17,6 +17,5 @@ usdt-impl = { path = "../usdt-impl", version = "0.1.6" }
 usdt-macro = { path = "../usdt-macro", version = "0.1.6" }
 
 [features]
-default = ["asm"]
 asm = ["usdt-impl/asm"]
 no-linker = ["usdt-impl/no-linker"]

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -13,9 +13,10 @@ dof = { path = "../dof", version = "0.1.4" }
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.8" }
 proc-macro2 = "1.0.24"
 structopt = "0.3.21"
-usdt-impl = { path = "../usdt-impl", version = "0.1.5" }
-usdt-macro = { path = "../usdt-macro", version = "0.1.5" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.6" }
+usdt-macro = { path = "../usdt-macro", version = "0.1.6" }
 
 [features]
 default = ["asm"]
 asm = ["usdt-impl/asm"]
+no-linker = ["usdt-impl/no-linker"]


### PR DESCRIPTION
platform dynamic linker

- Adds the `"no-linker"` feature flag to the `usdt` and `usdt-impl`
crates, forwarding the former to the latter
- Better conditional compilation of the `usdt_impl::internal` module,
based on the platform and new set of feature flags
- Combines some of the shared code used to generate the USDT macros
themselves into a `usdt-impl/src/common.rs` mod. The actual
implementation of the macro in the macos/linker case has been updated.
Previously, we were directly calling the (linker-defined) probe function
by creating a Rust fn with link-name of that mangled probe function.
This mapped directly onto the "usual" C implementation. That has been
updated to marshal the arguments just as we do on no-linker platforms,
and use the x86 call instruction directly. This all works, but it is a
difference, with the goal of being able to share code and test
everything more directly.
- Implements the linker/no-linker versions using the new shared code
- Adds tests for the new shared code
- Adds support for correctly extracting the module name in the no-linker
version of the code. This works by returning the containing file name in
addition to the function name from the `addr_to_info` function, and then
passing that as the module name in the DOF sent via ioctl(2).
- Adds simple test for the `asm_rec` function