### PR TITLE
Adds tests to verify useful error messages when compiling fails

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        asm-feature: [ "", "--features asm" ]
         no-linker-feature: [ "", "--features no-linker" ]
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +37,6 @@ jobs:
           --release
           --verbose
           --workspace
-          ${{ matrix.asm-feature }}
           ${{ matrix.no-linker-feature }}
 
   build-and-test:
@@ -47,7 +45,6 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest ]
-        asm-feature: [ "", "--features asm" ]
         no-linker-feature: [ "", "--features no-linker" ]
     steps:
       - uses: actions/checkout@v2
@@ -63,5 +60,4 @@ jobs:
           --no-fail-fast
           --verbose
           --workspace
-          ${{ matrix.asm-feature }}
           ${{ matrix.no-linker-feature }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"dtrace-parser",
 	"probe-test-build",
 	"probe-test-macro",
+	"tests/compile-errors",
 	"tests/empty",
 	"tests/namespace-conflict",
 	"tests/zero-arg-probe",
@@ -14,9 +15,6 @@ members = [
 default-members = [
 	"dof",
 	"dtrace-parser",
-	"tests/empty",
-	"tests/namespace-conflict",
-	"tests/zero-arg-probe",
 	"usdt",
 	"usdt-impl",
 	"usdt-macro"

--- a/dtrace-parser/src/lib.rs
+++ b/dtrace-parser/src/lib.rs
@@ -355,8 +355,20 @@ impl TryFrom<&str> for File {
             e.renamed_rules(|rule| match *rule {
                 Rule::DATA_TYPE | Rule::BIT_WIDTH => {
                     format!(
-                        "{:?} (Check that the probe argument is a supported data type)",
-                        rule
+                        "{:?}.\n\n{}",
+                        *rule,
+                        concat!(
+                            "Unsupported type, the following are supported:\n",
+                            "  - uint8_t\n",
+                            "  - uint16_t\n",
+                            "  - uint32_t\n",
+                            "  - uint64_t\n",
+                            "  - int8_t\n",
+                            "  - int16_t\n",
+                            "  - int32_t\n",
+                            "  - int64_t\n",
+                            "  - &str\n",
+                        )
                     )
                 }
                 _ => format!("{:?}", rule),

--- a/tests/compile-errors/Cargo.toml
+++ b/tests/compile-errors/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "compile-errors"
+version = "0.1.0"
+authors = ["Benjamin Naecker <ben@oxidecomputer.com>"]
+edition = "2018"
+
+[dependencies]
+usdt = { path = "../../usdt" }
+
+[dev-dependencies]
+trybuild = "1.0.41"
+
+[features]
+asm = ["usdt/asm"]
+no-linker = ["usdt/no-linker"]

--- a/tests/compile-errors/providers/type-mismatch.d
+++ b/tests/compile-errors/providers/type-mismatch.d
@@ -1,0 +1,3 @@
+provider mismatch {
+	probe bad(uint8_t);
+};

--- a/tests/compile-errors/providers/unsupported-type.d
+++ b/tests/compile-errors/providers/unsupported-type.d
@@ -1,0 +1,3 @@
+provider unsupported {
+	probe bad(float);
+};

--- a/tests/compile-errors/src/lib.rs
+++ b/tests/compile-errors/src/lib.rs
@@ -1,0 +1,14 @@
+#![feature(asm)]
+#![deny(warnings)]
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_compile_errors() {
+        let t = trybuild::TestCases::new();
+        t.compile_fail("src/type-mismatch.rs");
+        t.compile_fail("src/unsupported-type.rs");
+        t.compile_fail("src/no-closure.rs");
+        t.compile_fail("src/no-provider-file.rs");
+    }
+}

--- a/tests/compile-errors/src/no-closure.rs
+++ b/tests/compile-errors/src/no-closure.rs
@@ -1,0 +1,8 @@
+#![feature(asm)]
+
+usdt::dtrace_provider!("../../../tests/compile-errors/providers/type-mismatch.d");
+
+fn main() {
+    let arg: u8 = 0;
+    mismatch_bad!(arg);
+}

--- a/tests/compile-errors/src/no-closure.stderr
+++ b/tests/compile-errors/src/no-closure.stderr
@@ -1,0 +1,10 @@
+error: USDT probe macros should be invoked with a closure returning the arguments
+ --> $DIR/no-closure.rs:3:1
+  |
+3 | usdt::dtrace_provider!("../../../tests/compile-errors/providers/type-mismatch.d");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+7 |     mismatch_bad!(arg);
+  |     ------------------- in this macro invocation
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-errors/src/no-provider-file.rs
+++ b/tests/compile-errors/src/no-provider-file.rs
@@ -1,0 +1,5 @@
+#![feature(asm)]
+
+usdt::dtrace_provider!("non-existent.d");
+
+fn main() { }

--- a/tests/compile-errors/src/no-provider-file.stderr
+++ b/tests/compile-errors/src/no-provider-file.stderr
@@ -1,0 +1,7 @@
+error: proc macro panicked
+ --> $DIR/no-provider-file.rs:3:1
+  |
+3 | usdt::dtrace_provider!("non-existent.d");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: Could not read D source file "non-existent.d" in "$WORKSPACE/target/tests/compile-errors": Os { code: 2, kind: NotFound, message: "No such file or directory" }

--- a/tests/compile-errors/src/type-mismatch.rs
+++ b/tests/compile-errors/src/type-mismatch.rs
@@ -1,0 +1,8 @@
+#![feature(asm)]
+
+usdt::dtrace_provider!("../../../tests/compile-errors/providers/type-mismatch.d");
+
+fn main() {
+    let bad: f32 = 0.0;
+    mismatch_bad!(|| (bad));
+}

--- a/tests/compile-errors/src/type-mismatch.stderr
+++ b/tests/compile-errors/src/type-mismatch.stderr
@@ -1,0 +1,10 @@
+error[E0308]: mismatched types
+ --> $DIR/type-mismatch.rs:3:1
+  |
+3 | usdt::dtrace_provider!("../../../tests/compile-errors/providers/type-mismatch.d");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `f32`
+...
+7 |     mismatch_bad!(|| (bad));
+  |     ------------------------ in this macro invocation
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-errors/src/unsupported-type.rs
+++ b/tests/compile-errors/src/unsupported-type.rs
@@ -1,0 +1,8 @@
+#![feature(asm)]
+
+usdt::dtrace_provider!("../../../tests/compile-errors/providers/unsupported-type.d");
+
+fn main() {
+    let bad: u8 = 0;
+    unsupported_bad!(|| (bad));
+}

--- a/tests/compile-errors/src/unsupported-type.stderr
+++ b/tests/compile-errors/src/unsupported-type.stderr
@@ -1,0 +1,33 @@
+error: Error building provider definition in "../../../tests/compile-errors/providers/unsupported-type.d"
+
+Input is not a valid DTrace provider definition:
+ --> 2:12
+  |
+2 | probe bad(float);␊
+  |           ^---
+  |
+  = expected RIGHT_PAREN or DATA_TYPE.
+
+Unsupported type, the following are supported:
+  - uint8_t
+  - uint16_t
+  - uint32_t
+  - uint64_t
+  - int8_t
+  - int16_t
+  - int32_t
+  - int64_t
+  - &str
+
+ --> $DIR/unsupported-type.rs:3:1
+  |
+3 | usdt::dtrace_provider!("../../../tests/compile-errors/providers/unsupported-type.d");
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: cannot find macro `unsupported_bad` in this scope
+ --> $DIR/unsupported-type.rs:7:5
+  |
+7 |     unsupported_bad!(|| (bad));
+  |     ^^^^^^^^^^^^^^^

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -6,17 +6,15 @@ pub mod record;
 #[cfg_attr(any(target_os = "linux", not(feature = "asm")), allow(dead_code))]
 mod common;
 
-#[cfg_attr(any(target_os = "linux", not(feature = "asm")), path = "empty.rs")]
-#[cfg_attr(not(target_os = "macos"), path = "no-linker.rs")]
-#[cfg_attr(
-    all(target_os = "macos", feature = "no-linker"),
-    path = "no-linker.rs",
-    allow(unused_attributes)
-)]
+#[cfg_attr(target_os = "linux", path = "empty.rs")]
+#[cfg_attr(all(target_os = "macos", feature = "no-linker"), path = "no-linker.rs")]
 #[cfg_attr(
     all(target_os = "macos", not(feature = "no-linker")),
-    path = "linker.rs",
-    allow(unused_attributes)
+    path = "linker.rs"
+)]
+#[cfg_attr(
+    all(not(target_os = "linux"), not(target_os = "macos")),
+    path = "no-linker.rs"
 )]
 mod internal;
 

--- a/usdt-macro/src/lib.rs
+++ b/usdt-macro/src/lib.rs
@@ -79,7 +79,11 @@ pub fn dtrace_provider(item: proc_macro::TokenStream) -> proc_macro::TokenStream
         _ => panic!("DTrace provider must be a single literal string filename"),
     };
     let source = if filename.ends_with(".d") {
-        fs::read_to_string(&filename).expect("Could not read D source file")
+        fs::read_to_string(&filename).expect(&format!(
+            "Could not read D source file \"{}\" in {:?}",
+            &filename,
+            std::env::current_dir().unwrap()
+        ))
     } else {
         filename.clone()
     };

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -17,5 +17,6 @@ usdt-impl = { path = "../usdt-impl", version = "0.1.6" }
 usdt-macro = { path = "../usdt-macro", version = "0.1.6" }
 
 [features]
+default = ["asm"]
 asm = ["usdt-impl/asm"]
-no-linker = ["usdt-impl/no-linker"]
+no-linker = ["asm", "usdt-impl/no-linker"]


### PR DESCRIPTION
- Adds a suite of tests which verify the compiler error messages when
the `usdt` crate is misused in various likely ways. This includes a
provider definition with an unsupported type, a type mismatch in the
probe macro invocation, calling the probe macro without a closure, and
specifying a non-existent provider file to the proc macro or build.rs.
- Adds back the `asm` feature as a default and updates the CI config
accordingly.
- More appropriate conditional compilation of the actual internal
implementation file under various combinations of platform a feature
flags.