### PR TITLE
Prunes the dependency tree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
 	"dof",
 	"dtrace-parser",
+	"dusty",
 	"probe-test-build",
 	"probe-test-macro",
 	"tests/compile-errors",

--- a/dof/Cargo.toml
+++ b/dof/Cargo.toml
@@ -9,8 +9,10 @@ description = "Tools to read and write the DTrace Object Format (DOF)"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-goblin = "0.3.4"
-pretty-hex = "0.2.1"
-structopt = "0.3.21"
+goblin = { version = "0.3.4", optional = true, features = ["elf64", "mach64"] }
+pretty-hex = { version = "0.2.1", optional = true }
 thiserror = "1.0.24"
 zerocopy = "0.3.0"
+
+[features]
+des = ["pretty-hex", "goblin"]

--- a/dof/src/dof.rs
+++ b/dof/src/dof.rs
@@ -33,6 +33,7 @@ pub enum Error {
     UnsupportedObjectFile,
 
     /// An error related to parsing the object file
+    #[cfg(feature = "des")]
     #[error(transparent)]
     ObjectError(#[from] goblin::error::Error),
 
@@ -170,6 +171,7 @@ pub struct Section {
 
 impl Section {
     /// Construct a section from a DOF byte array.
+    #[cfg(feature = "des")]
     pub fn from_bytes(buf: &[u8]) -> Result<Section, Error> {
         crate::des::deserialize_section(buf)
     }

--- a/dof/src/lib.rs
+++ b/dof/src/lib.rs
@@ -28,12 +28,15 @@
 //! extracted from a DOF byte slice with the [`des::deserialize_raw_sections`] function.
 // Copyright 2021 Oxide Computer Company
 
+#[cfg(feature = "des")]
 pub mod des;
 pub mod dof;
 pub mod dof_bindings;
+#[cfg(feature = "des")]
 pub mod fmt;
 pub mod ser;
 
+#[cfg(feature = "des")]
 pub use crate::des::{
     collect_dof_sections, deserialize_section, extract_dof_sections, is_dof_section,
 };

--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dusty"
+version = "0.1.0"
+authors = ["Benjamin Naecker <ben@oxidecomputer.com>"]
+edition = "2018"
+description = "Tool to inspect USDT probe records in object files"
+license = "Apache-2.0"
+
+[dependencies]
+dof = { path = "../dof", features = [ "des" ] }
+structopt = "0.3.21"
+
+[dependencies.usdt]
+path = "../usdt"
+default-features = false
+features = ["des"]

--- a/dusty/src/main.rs
+++ b/dusty/src/main.rs
@@ -34,8 +34,8 @@ fn main() {
     }
 
     // File contains no DOF data. Try to parse out the ASM records inserted by the `usdt` crate.
-    if let Some(data) = usdt_impl::record::extract_probe_records(&cmd.file)
-        .expect("Failed to parse probe information")
+    if let Some(data) =
+        usdt::record::extract_probe_records(&cmd.file).expect("Failed to parse probe information")
     {
         // TODO This could use the raw/verbose arguments, by first converting into the C structs.
         println!("{:#?}", data)

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -12,14 +12,15 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 byteorder = "1.4.2"
 dof = { path = "../dof", version = "0.1.4" }
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.8" }
-goblin = { version = "0.3.4", features = [ "elf32", "elf64" ] }
+goblin = { version = "0.3.4", features = [ "elf32", "elf64" ], optional = true }
 libc = "0.2.88"
 proc-macro2 = "1.0.24"
 quote = "1.0.9"
 serde = { version = "1.0.124", features = ["derive"] }
-syn = "1.0.60"
+syn = { version = "1.0.60", features = ["full"] }
 thiserror = "1.0.24"
 
 [features]
 asm = []
-no-linker = []
+no-linker = ["asm"]
+des = ["goblin", "dof/des"]

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -1,6 +1,11 @@
 use serde::Deserialize;
 use thiserror::Error;
 
+#[cfg(any(
+    all(not(target_os = "linux"), not(target_os = "macos")),
+    feature = "des",
+    feature = "no-linker"
+))]
 pub mod record;
 
 #[cfg_attr(any(target_os = "linux", not(feature = "asm")), allow(dead_code))]

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::common;
-use crate::record::{parse_probe_records, PROBE_REC_VERSION};
+use crate::record::{process_section, PROBE_REC_VERSION};
 
 /// Compile a DTrace provider definition into Rust tokens that implement its probes.
 pub fn compile_providers(
@@ -112,7 +112,7 @@ fn extract_probe_records_from_section() -> Result<Option<Section>, crate::Error>
         let stop = (&dtrace_probes_stop as *const usize) as usize;
         std::slice::from_raw_parts(start as *const u8, stop - start)
     };
-    parse_probe_records(data)
+    process_section(data)
 }
 
 // Construct the ASM record for a probe. If `types` is `None`, then is is an is-enabled probe.

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -9,14 +9,13 @@ description = "Dust your Rust with USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dof = { path = "../dof", version = "0.1.4" }
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.8" }
-proc-macro2 = "1.0.24"
-structopt = "0.3.21"
-usdt-impl = { path = "../usdt-impl", version = "0.1.6" }
-usdt-macro = { path = "../usdt-macro", version = "0.1.6" }
+dof = { path = "../dof", version = "0.1.4", optional = true }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.8", optional = true }
+usdt-impl = { path = "../usdt-impl", version = "0.1.6", optional = true }
+usdt-macro = { path = "../usdt-macro", version = "0.1.6", optional = true }
 
 [features]
 default = ["asm"]
-asm = ["usdt-impl/asm"]
+asm = ["usdt-impl/asm", "dtrace-parser", "usdt-macro"]
 no-linker = ["asm", "usdt-impl/no-linker"]
+des = ["usdt-impl/des", "dof/des"]

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -138,7 +138,11 @@
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
+#[cfg(any(feature = "des", feature = "no-linker"))]
+pub use usdt_impl::record;
 pub use usdt_impl::Error;
+
+#[cfg(feature = "asm")]
 pub use usdt_macro::dtrace_provider;
 
 /// A simple struct used to build DTrace probes into Rust code in a build.rs script.


### PR DESCRIPTION
- Removes extraneous structopt dep from `dof` crate
- Adds a "des" feature to many of the packages. This is used to gate
inclusion of the tools for deserializing the probe records or DOF itself
from an object file. The effect on the dependency tree is to make the
large `goblin` dependency optional.
- Adds a small, separate binary crate `dusty`, which has the binary for
actually reading the DOF or ASM records from an object file. This is
really just the former `usdt/src/main.rs`, with appropriate changes to
the feature flags and depdendency tree.
- Note that the `"dof/des"` flag is not a default feature. It is opted
into via the `"usdt/des"` feature, which is _not_ implied by the "asm"
and "no-linker" features of the same crate. This allows the
deserialization tooling to be opted _out_ of, e.g., by most users of the
`usdt` crate. Note that the usdt::record module is conditionally
included on the basis of platform and the no-linker or asm features.