### PR TITLE
Adds integration test verifying that a probe is visible via `dtrace(1)`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"probe-test-build",
 	"probe-test-macro",
 	"tests/compile-errors",
+	"tests/does-it-work",
 	"tests/empty",
 	"tests/fake-cmd",
 	"tests/fake-lib",

--- a/tests/does-it-work/Cargo.toml
+++ b/tests/does-it-work/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "does-it-work"
+version = "0.1.0"
+authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
+           "Adam H. Leventhal <ahl@oxidecomputer.com>"]
+edition = "2018"
+
+[dependencies]
+usdt = { path = "../../usdt" }
+
+[build-dependencies]
+usdt = { path = "../../usdt" }
+
+[features]
+no-linker = ["usdt/no-linker"]

--- a/tests/does-it-work/build.rs
+++ b/tests/does-it-work/build.rs
@@ -1,0 +1,5 @@
+use usdt::Builder;
+
+fn main() {
+    Builder::new("test.d").build().unwrap();
+}

--- a/tests/does-it-work/src/main.rs
+++ b/tests/does-it-work/src/main.rs
@@ -1,0 +1,117 @@
+//! Small example which tests that this whole thing works. Specifically, this constructs and
+//! registers a single probe with arguments, and then verifies that this probe is visible to the
+//! `dtrace(1)` command-line tool.
+// Copyright 2021 Oxide Computer Company
+
+#![feature(asm)]
+
+use usdt::register_probes;
+
+include!(concat!(env!("OUT_DIR"), "/test.rs"));
+
+fn main() {
+    doesit_work!(|| (0, "something"));
+}
+
+#[allow(dead_code)]
+fn run_test(rx: std::sync::mpsc::Receiver<()>) {
+    register_probes().unwrap();
+    doesit_work!(|| (0, "something"));
+    let _ = rx.recv();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_test;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc::channel;
+    use std::thread;
+
+    #[test]
+    fn test_does_it_work() {
+        let (send, recv) = channel();
+        let thr = thread::spawn(move || run_test(recv));
+        let dtrace = Command::new("sudo")
+            .arg("dtrace")
+            .arg("-l")
+            .arg("-v")
+            .arg("-n")
+            .arg("doesit*:::")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("Could not start DTrace");
+        let output = dtrace
+            .wait_with_output()
+            .expect("Failed to read DTrace stdout");
+
+        // Kill the test thread
+        let _ = send.send(());
+
+        // Collect the actual output
+        let output = String::from_utf8_lossy(&output.stdout);
+        println!("{}", output);
+
+        // Check the line giving the full description of the probe
+        let mut lines = output.lines().skip_while(|line| !line.contains("doesit"));
+        let line = lines
+            .next()
+            .expect("Expected a line containing the provider name");
+        let mut parts = line.split_whitespace();
+        let _ = parts.next().expect("Expected an ID");
+
+        let provider = parts.next().expect("Expected a provider name");
+        assert!(
+            provider.starts_with("doesit"),
+            "Provider name appears incorrect: {}",
+            provider
+        );
+
+        let module = parts.next().expect("Expected a module name");
+        assert!(
+            module.starts_with("does_it_work"),
+            "Module name appears incorrect: {}",
+            module
+        );
+
+        let mangled_function = parts.next().expect("Expected a mangled function name");
+        assert!(
+            mangled_function.contains("does_it_work8run_test"),
+            "Mangled function name appears incorrect: {}",
+            mangled_function
+        );
+
+        let function = parts.next().expect("Expected a function name");
+        assert!(
+            function.contains("[does_it_work::run_test::"),
+            "Function name appears incorrect: {}",
+            function
+        );
+
+        let probe = parts.next().expect("Expected a probe name");
+        assert_eq!(probe, "work", "Probe name appears incorrect: {}", probe);
+
+        // Verify the argument types
+        let mut lines = lines.skip_while(|line| !line.contains("args[0]"));
+        let first = lines
+            .next()
+            .expect("Expected a line with the argument description")
+            .trim();
+        assert_eq!(
+            first, "args[0]: uint8_t",
+            "Argument is incorrect: {}",
+            first
+        );
+        let second = lines
+            .next()
+            .expect("Expected a line with the argument description")
+            .trim();
+        assert_eq!(
+            second, "args[1]: char *",
+            "Argument is incorrect: {}",
+            second
+        );
+
+        thr.join().expect("Failed to join test runner thread");
+    }
+}

--- a/tests/does-it-work/test.d
+++ b/tests/does-it-work/test.d
@@ -1,0 +1,3 @@
+provider doesit {
+	probe work(uint8_t, char*);
+};

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -99,7 +99,6 @@ pub fn extract_probe_records<P: AsRef<Path>>(file: P) -> Result<Option<Section>,
             if let Some(syms) = object.symbols {
                 let mut bounds = syms.iter().filter_map(|symbol| {
                     if let Ok((name, nlist)) = symbol {
-                        println!("{}", name);
                         if name.contains("__dtrace_probes") {
                             Some(nlist.n_value as usize)
                         } else {

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -31,8 +31,8 @@
 //!
 //! This procedural macro will generate a Rust macro for each probe defined in the provider. Note
 //! that including the `asm` feature is required; see [the notes](#notes) for a discussion. The
-//! `feature` directive and the invocation of `dtrace_provider` should both be at the crate root,
-//! i.e., `src/lib.rs` or `src/main.rs`.
+//! `feature` directive and the invocation of `dtrace_provider` **should both be at the crate
+//! root**, i.e., `src/lib.rs` or `src/main.rs`.
 //!
 //! One may then call the `start` probe via:
 //!


### PR DESCRIPTION
- Adds the `tests/does-it-work` crate to the workspace. This builds a
single probe, and then runs DTrace to verify that that probe is listed
with the correct properties. This relies on passwordless sudo, available
on GitHub's CI, or that the test itself is actually run with `sudo
cargo`.
- Removes stray println in the extraction of probe information from an
object file, left over from development.
- Bolds the comment in the README that the generated macros should be
included in the crate root.