### PR TITLE
update the path where we look for the provider.d file to appease rust-analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+**/target
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ which is nearly identical to the above example. However, there is no build.rs sc
 so in place of the `include!` macro, one finds the procedural macro:
 
 ```rust
-dtrace_provider!("probe-test-macro/test.d");
+dtrace_provider!("test.d");
 ```
 
 This macro generates the same macros as seen above, but does at the time the source

--- a/probe-test-macro/src/main.rs
+++ b/probe-test-macro/src/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use usdt::{dtrace_provider, register_probes};
 
 // Call the macro, which generates a Rust macro for each probe in the provider.
-dtrace_provider!("probe-test-macro/test.d");
+dtrace_provider!("test.d");
 
 fn main() {
     let duration = Duration::from_secs(1);

--- a/usdt-macro/src/lib.rs
+++ b/usdt-macro/src/lib.rs
@@ -33,9 +33,9 @@ use usdt_impl::compile_providers;
 /// in this case would be in the same directory as `"Cargo.toml"`.
 ///
 /// By default probe macros are named `{provider}_{probe}!`. Arguments are passed
-/// via a closure (or function) that returns a tuple. Note that the provided
-/// closure is only evaluated when the probe is enabled. One can then add points of
-/// instrumentation by invoking the macro:
+/// via a closure that returns a tuple. Note that the provided closure is only
+/// evaluated when the probe is enabled. One can then add points of instrumentation
+/// by invoking the macro:
 ///
 /// ```ignore
 /// fn do_stuff(count: u8, name: String) {

--- a/usdt-macro/src/lib.rs
+++ b/usdt-macro/src/lib.rs
@@ -1,8 +1,8 @@
 //! Prototype proc-macro crate for parsing a DTrace provider definition into Rust code.
 // Copyright 2021 Oxide Computer Company
 
-use std::fs;
 use std::iter::FromIterator;
+use std::{fs, path::Path};
 
 use quote::quote;
 use syn::{parse_macro_input, Lit};
@@ -79,10 +79,11 @@ pub fn dtrace_provider(item: proc_macro::TokenStream) -> proc_macro::TokenStream
         _ => panic!("DTrace provider must be a single literal string filename"),
     };
     let source = if filename.ends_with(".d") {
-        fs::read_to_string(&filename).expect(&format!(
+        let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let path = Path::new(&dir).join(&filename);
+        fs::read_to_string(path).expect(&format!(
             "Could not read D source file \"{}\" in {:?}",
-            &filename,
-            std::env::current_dir().unwrap()
+            &filename, dir,
         ))
     } else {
         filename.clone()

--- a/usdt-macro/src/lib.rs
+++ b/usdt-macro/src/lib.rs
@@ -79,8 +79,12 @@ pub fn dtrace_provider(item: proc_macro::TokenStream) -> proc_macro::TokenStream
         _ => panic!("DTrace provider must be a single literal string filename"),
     };
     let source = if filename.ends_with(".d") {
-        let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-        let path = Path::new(&dir).join(&filename);
+        let dir = std::env::var("CARGO_MANIFEST_DIR").map_or_else(
+            |_| std::env::current_dir().unwrap(),
+            |s| Path::new(&s).to_path_buf(),
+        );
+
+        let path = dir.join(&filename);
         fs::read_to_string(path).expect(&format!(
             "Could not read D source file \"{}\" in {:?}",
             &filename, dir,

--- a/usdt-macro/src/lib.rs
+++ b/usdt-macro/src/lib.rs
@@ -9,19 +9,17 @@ use syn::{parse_macro_input, Lit};
 
 use usdt_impl::compile_providers;
 
-/// Parse a DTrace provider file into Rust code.
+/// Generate DTrace probe macros from a provider definition file.
 ///
 /// This macro parses a DTrace provider.d file, given as a single literal string path. It then
-/// generates a Rust macro for each of the DTrace probe definitions. This is a simple way of
-/// generating Rust code that can be called normally, but which ultimately hooks up to DTrace probe
-/// points.
+/// generates a Rust macro for each of the DTrace probe definitions.
 ///
-/// For example, assume the file `"test.d"` has the following contents:
+/// For example, let's say the file `"test.d"` has the following contents:
 ///
 /// ```ignore
 /// provider test {
 ///     probe start(uint8_t);
-///     probe stop(char*, uint8_t);
+///     probe stop(char *, uint8_t);
 /// };
 /// ```
 ///
@@ -31,7 +29,13 @@ use usdt_impl::compile_providers;
 /// dtrace_provider!("test.d");
 /// ```
 ///
-/// One can then instrument the application or library as one might expect:
+/// The macro looks for the file relative to the root of the package, so `"test.d"`
+/// in this case would be in the same directory as `"Cargo.toml"`.
+///
+/// By default probe macros are named `{provider}_{probe}!`. Arguments are passed
+/// via a closure (or function) that returns a tuple. Note that the provided
+/// closure is only evaluated when the probe is enabled. One can then add points of
+/// instrumentation by invoking the macro:
 ///
 /// ```ignore
 /// fn do_stuff(count: u8, name: String) {
@@ -40,11 +44,18 @@ use usdt_impl::compile_providers;
 /// }
 /// ```
 ///
+/// The probe macro names can be customized by adding `, format =
+/// my_prefix_{provider}_{probe}` to the macro invocation where `{provider}` and
+/// `{probe}` are optional and will be substituted with the actual provider and
+/// probe names:
+///
+/// ```ignore
+/// dtrace_provider!("test.d", format = "dtrace_{provider}_{probe}");
+/// ```
+///
 /// Note
 /// ----
-/// This macro currently supports only a subset of the full D language, with the focus being on
-/// parsing a provider definition. As such, predicates and actions are not supported. Integers of
-/// specific bit-width, e.g., `uint16_t`, and `char *` are supported.
+/// The only supported types are integers of specific bit-width (e.g., `uint16_t`) and `char *`.
 #[proc_macro]
 pub fn dtrace_provider(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut tokens = item.into_iter().collect::<Vec<proc_macro::TokenTree>>();


### PR DESCRIPTION
@pfmooney observed that rust-analyzer runs builds from a different cwd than if one runs `cargo build` by hand. Consequently, the `dtrace_provider!` macro looks for the provider file in the wrong place. This PR uses `CARGO_MANIFEST_DIR` as the base directory in which we look for the specified provider file.