### PR TITLE
Avoid issuing ioctl on bad fd

### DIFF
--- a/tests/compile-errors/src/no-closure.stderr
+++ b/tests/compile-errors/src/no-closure.stderr
@@ -7,4 +7,4 @@ error: USDT probe macros should be invoked with a closure returning the argument
 7 |     mismatch_bad!(arg);
   |     ------------------- in this macro invocation
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `mismatch_bad` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-errors/src/type-mismatch.stderr
+++ b/tests/compile-errors/src/type-mismatch.stderr
@@ -7,4 +7,4 @@ error[E0308]: mismatched types
 7 |     mismatch_bad!(|| (bad));
   |     ------------------------ in this macro invocation
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `mismatch_bad` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-errors/src/unsupported-type.stderr
+++ b/tests/compile-errors/src/unsupported-type.stderr
@@ -3,8 +3,8 @@ error: Error building provider definition in "../../../tests/compile-errors/prov
 Input is not a valid DTrace provider definition:
  --> 2:12
   |
-2 | probe bad(float);␊
-  |           ^---
+2 |     probe bad(float);␊
+  |               ^---
   |
   = expected RIGHT_PAREN or DATA_TYPE.
 
@@ -24,7 +24,7 @@ Unsupported type, the following are supported:
 3 | usdt::dtrace_provider!("../../../tests/compile-errors/providers/unsupported-type.d");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `usdt::dtrace_provider` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: cannot find macro `unsupported_bad` in this scope
  --> $DIR/unsupported-type.rs:7:5

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -209,7 +209,11 @@ fn ioctl_section(buf: &[u8], modname: [std::os::raw::c_char; 64]) -> Result<(), 
     let ret = unsafe {
         let file = CString::new("/dev/dtrace/helper".as_bytes()).unwrap();
         let fd = libc::open(file.as_ptr(), libc::O_RDWR);
-        libc::ioctl(fd, cmd, data)
+        if fd < 0 {
+            fd
+        } else {
+            libc::ioctl(fd, cmd, data)
+        }
     };
     if ret == 0 {
         Ok(())
@@ -233,7 +237,11 @@ fn ioctl_section(buf: &[u8], modname: [std::os::raw::c_char; 64]) -> Result<(), 
     let ret = unsafe {
         let file = CString::new("/dev/dtracehelper".as_bytes()).unwrap();
         let fd = libc::open(file.as_ptr(), libc::O_RDWR);
-        libc::ioctl(fd, cmd, data)
+        if fd < 0 {
+            fd
+        } else {
+            libc::ioctl(fd, cmd, data)
+        }
     };
     if ret == 0 {
         Ok(())


### PR DESCRIPTION
Before:

If `/dev/dtrace/helper` was missing, due to (for example) a missing package, probe registration would return a "bad fd" error, after attempting to issue an ioctl to a defunct file descriptor.

After:

Well, if `/dev/dtrace/helper` is gone, things are still gonna fail, but the error will be slightly more comprehensible - it should fail due to "missing file/device", which is more accurate.