### PR TITLE
fix issues relating to data not living long enough

### DIFF
--- a/probe-test-build/src/main.rs
+++ b/probe-test-build/src/main.rs
@@ -24,8 +24,12 @@ fn main() {
         // Do some work.
         sleep(duration);
 
-        // Call the "stop" probe, which accepts a &str and a u8.
-        test_stop!(|| ("the probe has fired", counter));
+        // Call the "stop" probe, which accepts a string, u8, and string.
+        test_stop!(|| (
+            format!("the probe has fired {}", counter),
+            counter,
+            format!("{:x}", counter)
+        ));
 
         counter = counter.wrapping_add(1);
     }

--- a/probe-test-build/test.d
+++ b/probe-test-build/test.d
@@ -1,4 +1,4 @@
 provider test {
 	probe start(uint8_t);
-	probe stop(char*, uint8_t);
+	probe stop(char*, uint8_t, char*);
 };

--- a/probe-test-macro/src/main.rs
+++ b/probe-test-macro/src/main.rs
@@ -26,8 +26,12 @@ fn main() {
         // Do some work.
         sleep(duration);
 
-        // Call the "stop" probe, which accepts a &str and a u8.
-        test_stop!(|| ("the probe has fired", counter));
+        // Call the "stop" probe, which accepts a string, u8, and string.
+        test_stop!(|| (
+            format!("the probe has fired {}", counter),
+            counter,
+            format!("{:x}", counter)
+        ));
 
         counter = counter.wrapping_add(1);
     }

--- a/probe-test-macro/test.d
+++ b/probe-test-macro/test.d
@@ -1,4 +1,4 @@
 provider test {
 	probe start(uint8_t);
-	probe stop(char*, uint8_t);
+	probe stop(char*, uint8_t, char*);
 };

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -110,7 +110,7 @@ fn unpack_argument_lambda(types: &[dtrace_parser::DataType]) -> TokenStream {
     }
 }
 
-// Convert a supported data type to a type to store for the duration of the
+// Convert a supported data type to 1. a type to store for the duration of the
 // probe invocation and 2. a transformation for compatibility with an asm
 // register.
 fn asm_type_convert(


### PR DESCRIPTION
This expansion of one of the macros may best exemplify this change (hand re-formatted):

```rust
macro_rules ! test_stop {
    ($tree:tt) => {
        compile_error!("USDT probe macros should be invoked with a closure returning the arguments");
    };
    ($args_lambda:expr) => {
        {
            fn _type_check<S: AsRef<str>>(_: S, _: u8, _ :S) { }
            let _ = || {
                let args = $args_lambda();
                _type_check(args.0, args.1, args.2);
            };
        }
        unsafe {
            if $crate::__usdt_private_test::test_stop_enabled() != 0 {
                let args = $args_lambda();
                let arg_0 = [(args.0.as_ref() as &str).as_bytes(), &[0_u8]].concat();
                let arg_1 = (args.1 as i64);
                let arg_2 = [(args.2.as_ref() as &str).as_bytes(), &[0_u8]].concat();

                asm!(
                    ".reference {typedefs}",
                    "call {probe_fn}",
                    ".reference {stability}",
                    typedefs = sym $crate::__usdt_private_test::typedefs,
                    probe_fn = sym $crate::__usdt_private_test::test_stop,
                    stability = sym $crate::__usdt_private_test::stability,
                    in ("rdi") (arg_0.as_ptr() as i64),
                    in ("rsi") (arg_1),
                    in ("rdx") (arg_2.as_ptr() as i64),
                    options (nomem, nostack, preserves_flags),
                );
            }
        }
    };
}
```

Note in particular: we now store the converted value rather than just the `i64` value of the pointer. Storing only the numerical value didn't force the actual value to live long enough so the compiler could easily overwrite it.

Further, we now allow any `AsRef<str>` for a string value which we then convert (`as_ref().as_bytes()` etc)

To the careful reader: yes, this means that this mostly wasn't working / was working by accident. In particular, it would readily fail with dynamic strings .