### PR TITLE
Updates versions for publishing

### DIFF
--- a/dtrace-parser/Cargo.toml
+++ b/dtrace-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtrace-parser"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -3,6 +3,9 @@ name = "usdt-attr-macro"
 version = "0.1.0"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
+license = "Apache-2.0"
+description = "Procedural macro for generating Rust macros for USDT probes"
+repository = "https://github.com/oxidecomputer/usdt.git"
 
 [lib]
 proc-macro = true
@@ -12,4 +15,4 @@ proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
-usdt-impl = { path = "../usdt-impl", version = "0.1.8" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.9" }

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -11,7 +11,7 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 [dependencies]
 byteorder = "1.4.2"
 dof = { path = "../dof", version = "0.1.5", optional = true }
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.9" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.10" }
 goblin = { version = "0.3.4", features = [ "elf32", "elf64" ], optional = true }
 libc = "0.2.88"
 proc-macro2 = "1.0.24"

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -9,12 +9,12 @@ description = "Procedural macro for generating Rust macros for USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.9" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.10" }
 proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
-usdt-impl = { path = "../usdt-impl", version = "0.1.8" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.9" }
 
 [lib]
 proc-macro = true

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -10,9 +10,9 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 dof = { path = "../dof", version = "0.1.5", optional = true }
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.9", optional = true }
-usdt-impl = { path = "../usdt-impl", version = "0.1.8", optional = true }
-usdt-macro = { path = "../usdt-macro", version = "0.1.9", optional = true }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.10", optional = true }
+usdt-impl = { path = "../usdt-impl", version = "0.1.9", optional = true }
+usdt-macro = { path = "../usdt-macro", version = "0.1.10", optional = true }
 usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.0", optional = true }
 
 [features]


### PR DESCRIPTION
- update `dtrace-parser` 0.1.9 -> 0.1.10
- update dependents of `dtrace-parser`
- update `usdt-impl` 0.1.8 -> 0.1.9
- update dependents of `usdt-impl`
- update `usdt-macro` 0.1.9 -> 0.1.10
- update dependents of `usdt-macro`
- update `usdt-attr-macro` with license and other information required
  to publish
- update `usdt` 0.1.13 -> 0.1.14