### PR TITLE
Fixes bad dependencies related to the dof crate

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -17,5 +17,4 @@ rustc --version
 export RUST_BACKTRACE=1
 
 banner test
-ptime -m cargo test --release --no-fail-fast --verbose --workspace \
-    --features no-linker
+ptime -m cargo test --release --no-fail-fast --verbose --workspace

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-attr-macro"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,4 +15,4 @@ proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
-usdt-impl = { path = "../usdt-impl", version = "0.1.9" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.10" }

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -10,7 +10,6 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 byteorder = "1.4.2"
-dof = { path = "../dof", version = "0.1.5", optional = true }
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.10" }
 goblin = { version = "0.3.4", features = [ "elf32", "elf64" ], optional = true }
 libc = "0.2.88"
@@ -19,6 +18,12 @@ quote = "1.0.9"
 serde = { version = "1.0.124", features = ["derive"] }
 syn = { version = "1.0.60", features = ["full"] }
 thiserror = "1.0.24"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+dof = { path = "../dof", version = "0.1.5", optional = true }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+dof = { path = "../dof", version = "0.1.5" }
 
 [features]
 asm = []

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -14,7 +14,7 @@ proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
-usdt-impl = { path = "../usdt-impl", version = "0.1.9" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.10" }
 
 [lib]
 proc-macro = true

--- a/usdt-tests-common/src/lib.rs
+++ b/usdt-tests-common/src/lib.rs
@@ -1,11 +1,10 @@
-use std::env;
 use std::process::Command;
 
 #[cfg(target_os = "illumos")]
 pub fn root_command(name: &str) -> Command {
     // On illumos systems, we prefer pfexec(1) but allow some other command to
     // be specified through the environment.
-    let pfexec = env::var("PFEXEC").unwrap_or_else(|_| "/usr/bin/pfexec".to_string());
+    let pfexec = std::env::var("PFEXEC").unwrap_or_else(|_| "/usr/bin/pfexec".to_string());
     let mut cmd = Command::new(pfexec);
     cmd.arg(name);
     cmd

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -9,11 +9,16 @@ description = "Dust your Rust with USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dof = { path = "../dof", version = "0.1.5", optional = true }
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.10", optional = true }
-usdt-impl = { path = "../usdt-impl", version = "0.1.9", optional = true }
-usdt-macro = { path = "../usdt-macro", version = "0.1.10", optional = true }
-usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.0", optional = true }
+usdt-impl = { path = "../usdt-impl", version = "0.1.10", optional = true }
+usdt-macro = { path = "../usdt-macro", version = "0.1.11", optional = true }
+usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.1", optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+dof = { path = "../dof", version = "0.1.5", optional = true }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+dof = { path = "../dof", version = "0.1.5" }
 
 [features]
 default = ["asm"]


### PR DESCRIPTION
We previously tried to make the `dof` crate optional, but this wasn't
quite right. It's optional if the `no-linker` feature is _not_ enabled
_and_ one is not on a platform where that implementation is selected
regardless of the feature. One obvious case is illumos.

Unfortunately, platform-specific features are not yet implemented. This
commit instead makes the `dof` crate an optional dependency on macOS
platforms, and a required dependency on all other platforms. Note that
the `dof` crate is still pulled in on macOS if the `no-linker` feature
is explicitly enabled.

This commit also removes the `--features no-linker` bits from the
buildomat script, and bumps versions in preparation for a release with
this new dependency graph.