### PR TITLE
Fixes type checking for probes with zero arguments

### DIFF
--- a/dtrace-parser/src/lib.rs
+++ b/dtrace-parser/src/lib.rs
@@ -55,7 +55,8 @@ pub enum DataType {
     I32,
     I64,
     String,
-    Serializable,
+    /// Any type `T: serde::Serialize`, with the original type name stored as a string.
+    Serializable(String),
 }
 
 impl TryFrom<&Pair<'_, Rule>> for DataType {
@@ -111,7 +112,7 @@ impl DataType {
             DataType::I32 => "int32_t",
             DataType::I64 => "int64_t",
             DataType::String => "char*",
-            DataType::Serializable => "char*",
+            DataType::Serializable(_) => "char*",
         }
         .into()
     }
@@ -128,7 +129,7 @@ impl DataType {
             DataType::I32 => "::std::os::raw::c_int",
             DataType::I64 => "::std::os::raw::c_longlong",
             DataType::String => "*const ::std::os::raw::c_char",
-            DataType::Serializable => "*const ::std::os::raw::c_char",
+            DataType::Serializable(_) => "*const ::std::os::raw::c_char",
         }
         .into()
     }
@@ -145,7 +146,7 @@ impl DataType {
             DataType::I32 => "i32",
             DataType::I64 => "i64",
             DataType::String => "&str",
-            DataType::Serializable => "&impl ::serde::Serialize",
+            DataType::Serializable(ref name) => name.as_str(),
         }
         .into()
     }

--- a/tests/compile-errors/Cargo.toml
+++ b/tests/compile-errors/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 usdt = { path = "../../usdt" }
+serde = "*"
+serde_json = "*"
 
 [dev-dependencies]
 trybuild = "1.0.41"

--- a/tests/compile-errors/src/different-serializable-type.rs
+++ b/tests/compile-errors/src/different-serializable-type.rs
@@ -1,0 +1,26 @@
+//! Test that passing a type that is serializable, but not the same concrete type as the probe
+//! signature, fails compilation.
+
+// Copyright 2021 Oxide Computer Company
+
+#![feature(asm)]
+
+#[derive(serde::Serialize)]
+struct Expected {
+    x: u8
+}
+
+#[derive(serde::Serialize)]
+struct Different {
+    x: u8
+}
+
+#[usdt::provider]
+mod my_provider {
+    use super::Expected;
+    fn my_probe(_: Expected) {}
+}
+
+fn main() {
+    my_provider_my_probe!(|| Different { x: 0 });
+}

--- a/tests/compile-errors/src/different-serializable-type.stderr
+++ b/tests/compile-errors/src/different-serializable-type.stderr
@@ -1,0 +1,10 @@
+error[E0308]: mismatched types
+  --> $DIR/different-serializable-type.rs:18:1
+   |
+18 | #[usdt::provider]
+   | ^^^^^^^^^^^^^^^^^ expected struct `Expected`, found struct `Different`
+...
+25 |     my_provider_my_probe!(|| Different { x: 0 });
+   |     --------------------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `my_provider_my_probe` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/compile-errors/src/lib.rs
+++ b/tests/compile-errors/src/lib.rs
@@ -10,5 +10,7 @@ mod tests {
         t.compile_fail("src/unsupported-type.rs");
         t.compile_fail("src/no-closure.rs");
         t.compile_fail("src/no-provider-file.rs");
+        t.compile_fail("src/zero-arg-probe-type-check.rs");
+        t.compile_fail("src/different-serializable-type.rs");
     }
 }

--- a/tests/compile-errors/src/zero-arg-probe-type-check.rs
+++ b/tests/compile-errors/src/zero-arg-probe-type-check.rs
@@ -1,0 +1,14 @@
+//! Test that a zero-argument probe is correctly type-checked
+
+// Copyright 2021 Oxide Computer Company
+
+#![feature(asm)]
+
+#[usdt::provider]
+mod my_provider {
+    fn my_probe() {}
+}
+
+fn main() {
+    my_provider_my_probe!(|| "This should fail");
+}

--- a/tests/compile-errors/src/zero-arg-probe-type-check.stderr
+++ b/tests/compile-errors/src/zero-arg-probe-type-check.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+  --> $DIR/zero-arg-probe-type-check.rs:7:1
+   |
+7  | #[usdt::provider]
+   | ^^^^^^^^^^^^^^^^^
+   | |
+   | expected `()`, found `&str`
+   | expected due to this
+...
+13 |     my_provider_my_probe!(|| "This should fail");
+   |     --------------------------------------------- in this macro invocation
+   |
+   = note: this error originates in the macro `my_provider_my_probe` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/test-json/src/main.rs
+++ b/tests/test-json/src/main.rs
@@ -39,13 +39,14 @@ impl Serialize for NotJsonSerializable {
 #[usdt::provider]
 mod test_json {
     use super::{NotJsonSerializable, ProbeArg};
-    fn good(_: ProbeArg) {}
-    fn bad(_: NotJsonSerializable) {}
+    fn good(_: &ProbeArg) {}
+    fn bad(_: &NotJsonSerializable) {}
 }
 
 fn main() {
     usdt::register_probes().unwrap();
-    test_json_good!(|| ProbeArg::default());
+    let arg = ProbeArg::default();
+    test_json_good!(|| &arg);
 }
 
 #[cfg(test)]

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -62,7 +62,6 @@ fn compile_probe(
     let impl_block = quote! {
         {
             let mut is_enabled: u64;
-            // TODO can this block be option(pure)?
             unsafe {
                 asm!(
                     "990:   clr rax",

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -60,26 +60,28 @@ fn compile_probe(
     let probe_rec = asm_rec(provider_name, probe.name(), Some(probe.types()));
     let pre_macro_block = TokenStream::new();
     let impl_block = quote! {
-        let mut is_enabled: u64;
-        // TODO can this block be option(pure)?
-        unsafe {
-            asm!(
-                "990:   clr rax",
-                #is_enabled_rec,
-                out("rax") is_enabled,
-                options(nomem, nostack, preserves_flags)
-            );
-        }
-
-        if is_enabled != 0 {
-            #unpacked_args
+        {
+            let mut is_enabled: u64;
+            // TODO can this block be option(pure)?
             unsafe {
                 asm!(
-                    "990:   nop",
-                    #probe_rec,
-                    #in_regs
+                    "990:   clr rax",
+                    #is_enabled_rec,
+                    out("rax") is_enabled,
                     options(nomem, nostack, preserves_flags)
                 );
+            }
+
+            if is_enabled != 0 {
+                #unpacked_args
+                unsafe {
+                    asm!(
+                        "990:   nop",
+                        #probe_rec,
+                        #in_regs
+                        options(nomem, nostack, preserves_flags)
+                    );
+                }
             }
         }
     };


### PR DESCRIPTION
The internal type-checking mechanisms were broken for probes with no
arguments. One could write an argument closure returning _any_
arguments, and this would "pass" our internal type-checking, as we only
unpacked the _expected_ arguments from the closure. As there were no
expected arguments, there was no type-checking.

This commit modifies type-checking to verify that if the probe expects
zero arguments, we can assign the result of calling the argument closure
to a variable of type `()`. It also modifies the type checking of
serializable types. Before we used a generic parameter with a trait
bound `T: ::serde::Serialize`. This is actually not enough, since it
would successfully type-check an argument closure that returns a
_different_ type that is serializable than the one in the probe
signature. We now collect the actual, concrete type from the probe
signature during parsing, and insert that into the signature of the
type-check function as we would any other concrete type.

Two new try-build tests have been added that verify this behavior.