### PR TITLE
Add default features to usdt-impl crate

### DIFF
--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-attr-macro"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
-usdt-impl = { path = "../usdt-impl", version = "0.1.11" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.12", default-features = false }
 
 [dev-dependencies]
 rstest = "0.11.0"

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -28,3 +28,4 @@ dof = { path = "../dof", version = "0.1.5", default-features = false }
 [features]
 asm = []
 des = ["goblin", "dof", "dof/des"]
+default = ["asm"]

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -14,7 +14,7 @@ proc-macro2 = "1.0.24"
 serde_tokenstream = "0.1.2"
 syn = { version = "1.0.60", features = ["full"] }
 quote = "1.0.9"
-usdt-impl = { path = "../usdt-impl", version = "0.1.11" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.12", default-features = false }
 
 [lib]
 proc-macro = true

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -10,9 +10,9 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.11", optional = true }
-usdt-impl = { path = "../usdt-impl", version = "0.1.11", default-features = false }
-usdt-macro = { path = "../usdt-macro", version = "0.1.12" }
-usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.2" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.12", default-features = false }
+usdt-macro = { path = "../usdt-macro", version = "0.1.13" }
+usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.3" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }


### PR DESCRIPTION
This fixes an annoying issue related to feature-detection. Specifically,
it seems that we need the `usdt-impl` crate to specify the `asm` feature
as a default for the `default-features = false` bit in the top-level
`usdt` crate to work. Without this, it's not clear why, but the
`usdt-impl/asm` feature may or may not be selected dependending on how
consumers of the `usdt` crate set their feature flags.

This also bumps the version numbers, in preparation for a release.