### PR TITLE
Implements one-time registration of probes in a process

### DIFF
--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -2,6 +2,8 @@
 
 // Copyright 2021 Oxide Computer Company
 
+#![cfg_attr(feature = "asm", feature(asm))]
+
 use serde::Deserialize;
 use std::cell::RefCell;
 use thiserror::Error;

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -188,12 +188,11 @@ fn read_and_update_record_version(data: &[u8]) -> Result<u8, crate::Error> {
         // atomically exchange the data through a pointer. `AtomicU8::from_mut` might work, but
         // that would require another feature flag pinning us to a nightly compiler.
         let mut version = u8::MAX;
-        let mut existing_version = data.as_ptr();
-        #[allow(unused_assignments)]
+        let existing_version = data.as_ptr();
         unsafe {
             asm!(
                 "lock xchg al, [{}]",
-                inout(reg) existing_version,
+                in(reg) existing_version,
                 inout("al") version,
             );
         }

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -188,11 +188,11 @@ fn read_and_update_record_version(data: &[u8]) -> Result<u8, crate::Error> {
         // atomically exchange the data through a pointer. `AtomicU8::from_mut` might work, but
         // that would require another feature flag pinning us to a nightly compiler.
         let mut version = u8::MAX;
-        let existing_version = data.as_ptr();
+        let record_version_ptr = data.as_ptr();
         unsafe {
             asm!(
                 "lock xchg al, [{}]",
-                in(reg) existing_version,
+                in(reg) record_version_ptr,
                 inout("al") version,
             );
         }

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -183,7 +183,7 @@
 //! The library should clearly document that it defines and uses USDT probes, and that this
 //! function should be called by an application. Alternatively, library developers may call this
 //! function during some initialization routines required by their library. There is no harm in
-//! calling this method twice.
+//! calling this method multiple times, even in concurrent situations.
 //!
 //! Unique IDs
 //! ----------
@@ -312,6 +312,13 @@ impl Builder {
 /// This function collects the probes defined in an application, and forwards them to the DTrace
 /// kernel module. This _must_ be done for the probes to be visible via the `dtrace(1)` tool. See
 /// [probe_test_macro] for a detailed example.
+///
+/// Notes
+/// -----
+///
+/// This function registers all probes in a process's binary image, regardless of which crate
+/// actually defines the probes. It's also safe to call this function multiple times, even in
+/// concurrent situations. Probes will be registered at most once.
 ///
 /// [probe_test_macro]: https://github.com/oxidecomputer/usdt/tree/master/probe-test-macro
 pub fn register_probes() -> Result<(), Error> {


### PR DESCRIPTION
This commit adds support for guaranteed at-most-once registration of
probes, within a single process lifetime. The linker section into which
the probes are written is now writable. When reading a probe record, the
code checks that the probe's version is supported, and, if so,
atomically exchanges it for a sentinel value (255), returning the
original. Since any probe version greater than the crate's version is
skipped, probes that are handled will be skipped in any other invocation
of the `register_probes` function, as those probes' version is now the
sentinel. Unhandled probes will not be modified, but will still be
skipped, letting later versions of the library handle them.