### PR TITLE
Bump versions for release

### DIFF
--- a/dtrace-parser/Cargo.toml
+++ b/dtrace-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtrace-parser"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-attr-macro"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,12 +11,12 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 proc-macro = true
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.11" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.12" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.1.13", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
 
 [dev-dependencies]
 rstest = "0.11"

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -10,7 +10,7 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 byteorder = "1"
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.11" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.12" }
 goblin = { version = "0.4", features = [ "elf32", "elf64" ], optional = true }
 libc = "0.2"
 proc-macro2 = "1"

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -9,12 +9,12 @@ description = "Procedural macro for generating Rust macros for USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.5" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.12" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.1.13", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
 
 [lib]
 proc-macro = true

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -9,11 +9,11 @@ description = "Dust your Rust with USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.11", optional = true }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.12", optional = true }
 serde = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.1.13", default-features = false }
-usdt-macro = { path = "../usdt-macro", version = "0.1.14" }
-usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.4" }
+usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
+usdt-macro = { path = "../usdt-macro", version = "0.1.15" }
+usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.5" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }


### PR DESCRIPTION
- `dtrace-parser` 0.1.11 -> 0.1.12
- `usdt-impl` 0.1.13 -> 0.1.14
- `usdt-macro` 0.1.14 -> 0.1.15
- `usdt-attr-macro` 0.1.4 -> 0.1.5
- `usdt` 0.1.18 -> 0.1.19