### PR TITLE
Fixes incorrect use of cloned argument closure in empty implementation

### DIFF
--- a/usdt-impl/src/empty.rs
+++ b/usdt-impl/src/empty.rs
@@ -50,7 +50,7 @@ fn compile_probe(
     probe: &Probe,
     config: &crate::CompileProvidersConfig,
 ) -> TokenStream {
-    let impl_block = quote! { let _ = || ($args_lambda); };
+    let impl_block = quote! { let _ = || (__usdt_private_args_lambda()) ; };
     common::build_probe_macro(
         config,
         provider,


### PR DESCRIPTION
Closes #42