### PR TITLE
Supports crates using the new resolver v2

### DIFF
--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -18,5 +18,9 @@ syn = { version = "1", features = ["full"] }
 quote = "1"
 usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
 
+[features]
+default = ["asm"]
+asm = ["usdt-impl/asm"]
+
 [dev-dependencies]
 rstest = "0.11"

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -16,5 +16,9 @@ syn = { version = "1", features = ["full"] }
 quote = "1"
 usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
 
+[features]
+default = ["asm"]
+asm = ["usdt-impl/asm"]
+
 [lib]
 proc-macro = true

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.12", optional = true }
 serde = "1"
 usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
-usdt-macro = { path = "../usdt-macro", version = "0.1.15" }
-usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.5" }
+usdt-macro = { path = "../usdt-macro", version = "0.1.15", default-features = false }
+usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.5", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }
@@ -23,5 +23,5 @@ dof = { path = "../dof", version = "0.1.5", default-features = false }
 
 [features]
 default = ["asm"]
-asm = ["usdt-impl/asm", "dtrace-parser"]
+asm = ["usdt-impl/asm", "usdt-macro/asm", "usdt-attr-macro/asm", "dtrace-parser"]
 des = ["usdt-impl/des", "dof/des"]


### PR DESCRIPTION
The dependency resolver v2 does not merge features in the same way as
prior versions. V2 is also the default as of Rust edition 2021. This
could lead to incorrectly building multiple versions of the usdt crate,
including one erroneously selecting the empty implementation.

This adds feature flags for the `usdt-macro` and `usdt-attr-macro`
crates that ensure we're building with the correct set of flags
regardless of which resolver is used.