### PR TITLE
Allows renaming the provider, rather than the probe module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ members = [
 	"tests/empty",
 	"tests/fake-cmd",
 	"tests/fake-lib",
+    "tests/rename",
+    "tests/rename-builder",
 	"tests/test-json",
 	"tests/test-unique-id",
 	"tests/zero-arg-probe",

--- a/tests/rename-builder/Cargo.toml
+++ b/tests/rename-builder/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rename-builder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+usdt = { path = "../../usdt" }
+serde = "1"
+
+[build-dependencies]
+usdt = { path = "../../usdt" }

--- a/tests/rename-builder/build.rs
+++ b/tests/rename-builder/build.rs
@@ -1,0 +1,5 @@
+use usdt::Builder;
+
+fn main() {
+    Builder::new("test.d").module("still_test").build().unwrap();
+}

--- a/tests/rename-builder/src/main.rs
+++ b/tests/rename-builder/src/main.rs
@@ -1,0 +1,16 @@
+//! Test verifying that renaming the provider/probes in various ways works when using a build
+//! script.
+
+// Copyright 2021 Oxide Computer Company
+
+#![feature(asm)]
+#![cfg_attr(target_os = "macos", feature(asm_sym))]
+include!(concat!(env!("OUT_DIR"), "/test.rs"));
+
+fn main() {
+    usdt::register_probes().unwrap();
+
+    // Renamed the module that the probes are generated to `still_test`. So naming them as
+    // `test::start_work` will fail.
+    still_test::start_work!(|| 0);
+}

--- a/tests/rename-builder/test.d
+++ b/tests/rename-builder/test.d
@@ -1,0 +1,4 @@
+provider test {
+	probe start_work(uint8_t);
+	probe stop_work(char*, uint8_t, char*);
+};

--- a/tests/rename/Cargo.toml
+++ b/tests/rename/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rename"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+usdt = { path = "../../usdt" }
+serde = "1"

--- a/tests/rename/src/main.rs
+++ b/tests/rename/src/main.rs
@@ -1,0 +1,16 @@
+//! Integration test verifying that provider modules are renamed correctly.
+
+// Copyright 2021 Oxide Computer Company
+
+#![feature(asm)]
+#![cfg_attr(target_os = "macos", feature(asm_sym))]
+
+#[usdt::provider(provider = "something", probe_format = "probe_{probe}")]
+mod probes {
+    fn something() {}
+}
+
+fn main() {
+    usdt::register_probes().unwrap();
+    probes::probe_something!(|| ());
+}

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -212,12 +212,12 @@ pub(crate) fn build_probe_macro(
     pre_macro_block: TokenStream,
     impl_block: TokenStream,
 ) -> TokenStream {
-    let macro_path = config.macro_path(&provider.name, probe_name);
-    let macro_name = config.probe_ident(&provider.name, probe_name);
+    let module = config.module_ident();
+    let macro_name = config.probe_ident(probe_name);
     let type_check_block =
         generate_type_check(&provider.name, &provider.use_statements, probe_name, types);
     let no_args_match = if types.is_empty() {
-        quote! { () => { crate::#macro_path!(|| ()) }; }
+        quote! { () => { crate::#module::#macro_name!(|| ()) }; }
     } else {
         quote! {}
     };

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -73,76 +73,41 @@ pub enum Error {
 
 #[derive(Default, Debug, Deserialize)]
 pub struct CompileProvidersConfig {
-    pub probe_path: Option<String>,
-    pub probe_name: Option<String>,
+    pub provider: Option<String>,
+    pub probe_format: Option<String>,
+    pub module: Option<String>,
 }
 
 impl CompileProvidersConfig {
     /// Return the formatted name of a probe.
-    pub fn format_probe(&self, provider_name: &str, probe_name: &str) -> String {
-        if let Some(fmt) = &self.probe_name {
-            fmt.replace("{provider}", provider_name)
-                .replace("{probe}", probe_name)
+    pub fn format_probe(&self, probe_name: &str) -> String {
+        if let Some(fmt) = &self.probe_format {
+            fmt.replace(
+                "{provider}",
+                self.provider
+                    .as_ref()
+                    .expect("Expected a provider name when formatting a rpobe"),
+            )
+            .replace("{probe}", probe_name)
         } else {
             String::from(probe_name)
         }
     }
 
     /// Return the formatted name of the probe as an identifier.
-    pub fn probe_ident(&self, provider_name: &str, probe_name: &str) -> proc_macro2::Ident {
-        quote::format_ident!("{}", self.format_probe(provider_name, probe_name))
+    pub fn probe_ident(&self, probe_name: &str) -> proc_macro2::Ident {
+        quote::format_ident!("{}", self.format_probe(probe_name))
     }
 
-    /// Return the full formatted path of the provider.
-    pub fn format_path(&self, provider_name: &str) -> String {
-        if let Some(fmt) = &self.probe_path {
-            fmt.replace("{provider}", provider_name)
-        } else {
-            String::from(provider_name)
-        }
+    /// Return the formatted module name as an identifier.
+    pub fn module_ident(&self) -> proc_macro2::Ident {
+        let name = self.module.as_ref().unwrap_or_else(|| {
+            self.provider
+                .as_ref()
+                .expect("Expected a provider name when making a module ident")
+        });
+        quote::format_ident!("{}", name)
     }
-
-    /// Return the formatted module names for a provider, as a list of identifiers.
-    pub fn provider_modules(&self, provider_name: &str) -> Vec<proc_macro2::Ident> {
-        self.format_path(provider_name)
-            .split("::")
-            .filter(|name| !name.is_empty())
-            .map(|name| quote::format_ident!("{}", name))
-            .collect()
-    }
-
-    pub fn provider_module(&self, provider_name: &str) -> proc_macro2::TokenStream {
-        let mods = self.provider_modules(provider_name).into_iter().rev();
-        quote::quote! { #(#mods)::* }
-    }
-
-    /// Return the full path of a probe macro.
-    pub fn macro_path(&self, provider_name: &str, probe_name: &str) -> proc_macro2::TokenStream {
-        let ident = self.probe_ident(provider_name, probe_name);
-        self.provider_modules(provider_name).into_iter().rev().fold(
-            quote::quote! { #ident },
-            |current, module| quote::quote! { #module :: #current },
-        )
-    }
-}
-
-/// Generate a possibly-nested list of modules, containing the given probe macros.
-fn wrap_probes_in_modules(
-    config: &CompileProvidersConfig,
-    provider: &Provider,
-    macros: proc_macro2::TokenStream,
-) -> proc_macro2::TokenStream {
-    config
-        .provider_modules(&provider.name)
-        .into_iter()
-        .rev()
-        .fold(macros, |inner, module| {
-            quote::quote! {
-                pub(crate) mod #module {
-                    #inner
-                }
-            }
-        })
 }
 
 // Compile DTrace provider source code into Rust.
@@ -532,32 +497,15 @@ mod test {
     #[test]
     fn test_compile_providers_config() {
         let config = CompileProvidersConfig {
-            probe_path: Some(String::from("a::{provider}::b")),
-            probe_name: Some(String::from("probe_{probe}")),
+            provider: Some(String::from("prov")),
+            probe_format: Some(String::from("probe_{probe}")),
+            module: Some(String::from("not_prov")),
         };
-        assert_eq!(config.format_probe("prov", "prob"), "probe_prob");
-        assert_eq!(config.format_path("prov"), "a::prov::b");
+        assert_eq!(config.format_probe("prob"), "probe_prob");
+        let module = config.module_ident();
         assert_eq!(
-            config.macro_path("prov", "prob").to_string(),
-            quote::quote! { a::prov::b::probe_prob }.to_string()
-        );
-
-        let config = CompileProvidersConfig {
-            probe_path: None,
-            probe_name: None,
-        };
-        assert_eq!(
-            config.macro_path("prov", "prob").to_string(),
-            quote::quote! { prov::prob }.to_string()
-        );
-
-        let config = CompileProvidersConfig {
-            probe_path: Some(String::new()),
-            probe_name: None,
-        };
-        assert_eq!(
-            config.macro_path("prov", "prob").to_string(),
-            quote::quote! { prob }.to_string()
+            quote::quote! { #module }.to_string(),
+            quote::quote! { not_prov }.to_string(),
         );
     }
 }

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -129,14 +129,43 @@
 //!
 //! ## Configurable names
 //!
-//! When using the attribute macro or build.rs versions of the code-generator, the paths at which
-//! the probe macros are available can be configured. For example, the attribute macro accepts
-//! `probe_path` and `probe_name` arguments, which are string literals. These give the module path
-//! and macro name, respectively, of the resulting probe. For example, an attribute like
-//! `#[usdt::provider(probe_path = "foo::{provider}", probe_name = "probe_{probe}")` will result in
-//! probe macros like `foo::{provider}::probe_{probe}`, where the keys `{provider}` and `{probe}`
-//! will be interpolated with the actual provider and probe names. So given a provider `bar` and
-//! probe `baz`, the macro would be, in full: `foo::bar::probe_baz!`.
+//! When using the attribute macro or build.rs versions of the code-generator, the names of the
+//! provider and/or probes may be configured. Specifically, the `probe_format` argument to the
+//! attribute macro or `Builder` method sets a format string used to generate the names of the
+//! probe macros. This can be any string, and will have the keys `{provider}` and `{probe}`
+//! interpolated to the actual names of the provider and probe. As an example, consider a provider
+//! named `foo` with a probe named `bar`, and a format string of `probe_{provider}_{probe}` -- the
+//! name of the generated probe macro will be `probe_foo_bar`.
+//!
+//! In addition, when using the attribute macro version, the name of the _provider_ as seen by
+//! DTrace can be configured. This defaults to the name of the provider module. For example,
+//! consider a module like this:
+//!
+//! ```ignore
+//! #[usdt::provider(provider = "foo")]
+//! mod probes {
+//!     fn bar() {
+//! }
+//! ```
+//!
+//! The probe `bar` will appear in DTrace as `foo:::bar`, and will be accessible in Rust via the
+//! macro `probes::bar!`. Note that it's not possible to rename the probe module when using the
+//! attribute macro version.
+//!
+//! Conversely, one can change the name of the generated provider _module_ when using the builder
+//! version, but not the name of the provider as it appears to DTrace. Given a file `"test.d"` that
+//! names a provider `foo` and a probe `bar`, consider this code:
+//!
+//! ```ignore
+//! usdt::Builder::new("test.d")
+//!     .module("probes")
+//!     .build()
+//!     .unwrap();
+//! ```
+//!
+//! This probe `bar` will appear in DTrace as `foo:::bar`, but will now be accessible in Rust via
+//! the macro `probes::bar!`. Note that it's not possible to rename the provider as it appears in
+//! DTrace when using the builder version.
 //!
 //! Examples
 //! --------

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -335,21 +335,14 @@ impl Builder {
     ///
     /// The provided format may include the tokens `{provider}` and `{probe}`, which will be
     /// substituted with the names of the provider and probe. The default is `"{probe}"`.
-    pub fn probe_name(mut self, format: &str) -> Self {
-        self.config.probe_name = Some(format.to_string());
+    pub fn probe_format(mut self, format: &str) -> Self {
+        self.config.probe_format = Some(format.to_string());
         self
     }
 
-    /// Set the module path of the generated probe macros.
-    ///
-    /// The generated macros can be emitted within zero or more nested modules, to support
-    /// namespacing. This sets the full list of those generated modules, and defaults to
-    /// `"{provider}"`.
-    ///
-    /// For example, given the string `"some::mod::{provider}"`, for a provider named `foo`, the
-    /// generated probe macros will be available as `some::mod::provider::{probe}`.
-    pub fn probe_path(mut self, format: &str) -> Self {
-        self.config.probe_path = Some(format.to_string());
+    /// Set the name of the module containing the generated probe macros.
+    pub fn module(mut self, module: &str) -> Self {
+        self.config.module = Some(module.to_string());
         self
     }
 


### PR DESCRIPTION
After the change to module-scoped macros, we kept the ability to rename
the probe module from the earlier implementation. This meant the
procedural macros might rename the module, which is a bit confusing.
This switches to support renaming the _provider_, but not the module.
The module can be named to whatever the user wishes, and the probes are
always available in that scope. If the provider name is not chosen in
the attribute macro, it defaults to the module name, but this can be
overridden.