### PR TITLE
Documentation cleanup and bump versions for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ There are three mechanisms for converting the D probe definitions into Rust.
 3. An attribute macro, `usdt::provider`.
 
 The generated code is the same in all cases, though the third provides a bit more flexibility
-than the first two. See [below][Serializable types] for more details, but briefly, the third
+than the first two. See [below](#serializable-types) for more details, but briefly, the third
 form supports probe arguments of any type that implement [`serde::Seralize`][2]. These different
 versions are shown in the crates `probe-test-{build,macro,attr}` respectively.
 

--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -12,6 +12,6 @@ structopt = "0.3.21"
 
 [dependencies.usdt]
 path = "../usdt"
-version = "0.1.11"
+version = "0.2.0"
 default-features = false
 features = ["des"]

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-attr-macro"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.2.0", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.1.14"
+version = "0.2.0"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.1.15"
+version = "0.2.0"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -14,7 +14,7 @@ proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.2.0", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.1.19"
+version = "0.2.0"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -11,9 +11,9 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 [dependencies]
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.12", optional = true }
 serde = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.1.14", default-features = false }
-usdt-macro = { path = "../usdt-macro", version = "0.1.15", default-features = false }
-usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.1.5", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.2.0", default-features = false }
+usdt-macro = { path = "../usdt-macro", version = "0.2.0", default-features = false }
+usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.2.0", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -100,8 +100,8 @@
 //! #[usdt::provider]
 //! mod test {
 //!     use crate::Arg;
-//!     fn start(x: u8) {}
-//!     fn stop(arg: &Arg) {}
+//!     fn start_work(x: u8) {}
+//!     fn stop_work(arg: &Arg) {}
 //! }
 //! ```
 //!
@@ -110,7 +110,7 @@
 //! is used to access the named key of a JSON-encoded string. For example:
 //!
 //! ```bash
-//! $ dtrace -n 'stop { printf("%s", json(copyinstr(arg0), "ok.buffer[0]")); }'
+//! $ dtrace -n 'stop_work { printf("%s", json(copyinstr(arg0), "ok.buffer[0]")); }'
 //! ```
 //!
 //! would print the first element of the vector `Arg::buffer`.


### PR DESCRIPTION
- `usdt-impl` 0.1.14 -> 0.2.0
- `usdt-macro` 0.1.15 -> 0.2.0
- `usdt-attr-macro` 0.1.5 -> 0.2.0
- `usdt` 0.1.19 -> 0.2.0