### PR TITLE
Moves extern symbol definitions into the macro bodies on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 	"tests/empty",
 	"tests/fake-cmd",
 	"tests/fake-lib",
+	"tests/modules",
     "tests/rename",
     "tests/rename-builder",
 	"tests/test-json",

--- a/tests/modules/Cargo.toml
+++ b/tests/modules/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "modules"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+usdt = { path = "../../usdt" }
+serde = "1"

--- a/tests/modules/src/inner.rs
+++ b/tests/modules/src/inner.rs
@@ -1,0 +1,4 @@
+#[usdt::provider(provider = "modules")]
+pub mod probes {
+    fn am_i_visible() {}
+}

--- a/tests/modules/src/main.rs
+++ b/tests/modules/src/main.rs
@@ -1,0 +1,15 @@
+#![feature(asm)]
+#![cfg_attr(target_os = "macos", feature(asm_sym))]
+
+mod inner;
+
+fn main() {
+    usdt::register_probes().expect("Could not register probes");
+    // Verify that we can call the probe from its full path.
+    inner::probes::am_i_visible!(|| ());
+
+    // This is an overly-cautious test for macOS. We define extern symbols inside each expanded
+    // probe macro, with a link-name for a symbol that the macOS linker will generate for us. This
+    // checks that there is no issue defining these locally-scoped extern symbols multiple times.
+    inner::probes::am_i_visible!(|| ());
+}

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -209,7 +209,6 @@ pub(crate) fn build_probe_macro(
     provider: &Provider,
     probe_name: &str,
     types: &[DataType],
-    pre_macro_block: TokenStream,
     impl_block: TokenStream,
 ) -> TokenStream {
     let module = config.module_ident();
@@ -222,7 +221,6 @@ pub(crate) fn build_probe_macro(
         quote! {}
     };
     quote! {
-        #pre_macro_block
         #[allow(unused_macros)]
         macro_rules! #macro_name {
             #no_args_match

--- a/usdt-impl/src/empty.rs
+++ b/usdt-impl/src/empty.rs
@@ -53,7 +53,7 @@ fn compile_provider(provider: &Provider, config: &crate::CompileProvidersConfig)
         .collect::<Vec<_>>();
     let module = config.module_ident();
     quote! {
-        mod #module {
+        pub(crate) mod #module {
             #(#probe_impls)*
         }
     }
@@ -65,14 +65,7 @@ fn compile_probe(
     config: &crate::CompileProvidersConfig,
 ) -> TokenStream {
     let impl_block = quote! { let _ = || (__usdt_private_args_lambda()) ; };
-    common::build_probe_macro(
-        config,
-        provider,
-        &probe.name,
-        &probe.types,
-        quote! {},
-        impl_block,
-    )
+    common::build_probe_macro(config, provider, &probe.name, &probe.types, impl_block)
 }
 
 pub fn register_probes() -> Result<(), crate::Error> {

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -53,7 +53,7 @@ fn compile_provider(provider: &Provider, config: &crate::CompileProvidersConfig)
         .collect::<Vec<_>>();
     let module = config.module_ident();
     quote! {
-        mod #module {
+        pub(crate) mod #module {
             #(#probe_impls)*
         }
     }
@@ -67,7 +67,6 @@ fn compile_probe(
     let (unpacked_args, in_regs) = common::construct_probe_args(&probe.types);
     let is_enabled_rec = emit_probe_record(&provider.name, &probe.name, None);
     let probe_rec = emit_probe_record(&provider.name, &probe.name, Some(&probe.types));
-    let pre_macro_block = TokenStream::new();
     let impl_block = quote! {
         {
             let mut is_enabled: u64;
@@ -93,14 +92,7 @@ fn compile_probe(
             }
         }
     };
-    common::build_probe_macro(
-        config,
-        provider,
-        &probe.name,
-        &probe.types,
-        pre_macro_block,
-        impl_block,
-    )
+    common::build_probe_macro(config, provider, &probe.name, &probe.types, impl_block)
 }
 
 fn extract_probe_records_from_section() -> Result<Option<Section>, crate::Error> {


### PR DESCRIPTION
On macOS, we define extern functions with valid Rust identifiers for a
few key bits of information about the providers and probes. These
symbols are generated by the macOS linker, but we collect their names
from the output of `dtrace -h` during macro generation.

Previously these symbols were defined in a separate scope that the
actual probe declarative macro bodies. For example, the stability symbol
was defined in the provider module, so one "level" of scope above the
probe macro bodies. This means we need to be able to refer to that
symbol by path, which is difficult, since the probe modules can
generally be anywhere in the crate at this point.

This moves those extern symbols directly into the scope of the probe
macro body. They can just be referred to without any other path
components on their names, since they're "right next" to the place
they're used.