### PR TITLE
Adds support for translating double-underscores to dashes

### DIFF
--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -12,5 +12,5 @@ structopt = "0.3.21"
 
 [dependencies.usdt]
 path = "../usdt"
-version = "0.2.1"
+version = "0.3.0"
 features = ["asm", "des"]

--- a/tests/compile-errors/src/unsupported-type.stderr
+++ b/tests/compile-errors/src/unsupported-type.stderr
@@ -1,24 +1,23 @@
 error: Error building provider definition in "../../../tests/compile-errors/providers/unsupported-type.d"
 
-Input is not a valid DTrace provider definition:
- --> 2:12
-  |
-2 |     probe bad(float);␊
-  |               ^---
-  |
-  = expected RIGHT_PAREN or DATA_TYPE.
+       Input is not a valid DTrace provider definition:
+        --> 2:12
+         |
+       2 |     probe bad(float);␊
+         |               ^---
+         |
+         = expected RIGHT_PAREN or DATA_TYPE.
 
-Unsupported type, the following are supported:
-  - uint8_t
-  - uint16_t
-  - uint32_t
-  - uint64_t
-  - int8_t
-  - int16_t
-  - int32_t
-  - int64_t
-  - &str
-
+       Unsupported type, the following are supported:
+         - uint8_t
+         - uint16_t
+         - uint32_t
+         - uint64_t
+         - int8_t
+         - int16_t
+         - int32_t
+         - int64_t
+         - &str
   --> src/unsupported-type.rs:18:1
    |
 18 | usdt::dtrace_provider!("../../../tests/compile-errors/providers/unsupported-type.d");

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-attr-macro"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.2.1", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.3.0", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -99,6 +99,7 @@ pub fn generate_type_check(
     quote! {
         let __usdt_private_args_lambda = $args_lambda;
         #[allow(unused_imports)]
+        #[allow(non_snake_case)]
         #(#use_statements)*
         fn #type_check_function (#(#type_check_args),*) { }
         let _ = || {
@@ -281,6 +282,7 @@ mod tests {
         let expected = quote! {
             let __usdt_private_args_lambda = $args_lambda;
             #[allow(unused_imports)]
+            #[allow(non_snake_case)]
             fn __usdt_private_provider_probe_type_check(
                 _: impl ::std::borrow::Borrow<u8>,
                 _: impl ::std::borrow::Borrow<i64>
@@ -303,6 +305,7 @@ mod tests {
         let expected = quote! {
             let __usdt_private_args_lambda = $args_lambda;
             #[allow(unused_imports)]
+            #[allow(non_snake_case)]
             fn __usdt_private_provider_probe_type_check(_: impl AsRef<str>) { }
             let _ = || {
                 let args = (__usdt_private_args_lambda.clone()(),);
@@ -322,6 +325,7 @@ mod tests {
         let expected = quote! {
             let __usdt_private_args_lambda = $args_lambda;
             #[allow(unused_imports)]
+            #[allow(non_snake_case)]
             fn __usdt_private_provider_probe_type_check(_: impl AsRef<[u8]>) { }
             let _ = || {
                 let args = (__usdt_private_args_lambda.clone()(),);
@@ -341,6 +345,7 @@ mod tests {
         let expected = quote! {
             let __usdt_private_args_lambda = $args_lambda;
             #[allow(unused_imports)]
+            #[allow(non_snake_case)]
             use my_module::MyType;
             fn __usdt_private_provider_probe_type_check(_: impl ::std::borrow::Borrow<MyType>) { }
             let _ = || {

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -308,7 +308,7 @@ thread_local! {
 /// -------
 /// ```ignore
 /// #![feature(asm)]
-/// #![cfg_attr(target_os = "macos, feature(asm_sym))]
+/// #![cfg_attr(target_os = "macos", feature(asm_sym))]
 /// #[usdt::provider]
 /// mod with_id {
 ///     fn work_started(_: &usdt::UniqueId) {}
@@ -346,7 +346,7 @@ thread_local! {
 ///
 /// ```compile_fail
 /// #![feature(asm)]
-/// #![cfg_attr(target_os = "macos, feature(asm_sym))]
+/// #![cfg_attr(target_os = "macos", feature(asm_sym))]
 /// #[usdt::provider]
 /// mod with_id {
 ///     fn work_started(_: &usdt::UniqueId) {}

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -336,8 +336,8 @@ pub(crate) fn emit_probe_record(prov: &str, probe: &str, types: Option<&[DataTyp
         version = PROBE_REC_VERSION,
         n_args = n_args,
         flags = if is_enabled { 1 } else { 0 },
-        prov = prov,
-        probe = probe,
+        prov = prov.replace("__", "-"),
+        probe = probe.replace("__", "-"),
         arguments = arguments,
         yeet = if cfg!(target_os = "illumos") {
             // The illumos linker may yeet our probes section into the trash under
@@ -551,5 +551,20 @@ mod test {
                 .find(&format!(".asciz \"{}\"", typ.to_c_type()))
                 .is_some());
         }
+    }
+
+    #[test]
+    fn test_emit_probe_record_dunders() {
+        let provider = "provider";
+        let probe = "my__probe";
+        let types = [
+            DataType::Native(dtrace_parser::DataType::U8),
+            DataType::Native(dtrace_parser::DataType::String),
+        ];
+        let record = emit_probe_record(provider, probe, Some(&types));
+        assert!(
+            record.contains("my-probe"),
+            "Expected double-underscores to be translated to a single dash"
+        );
     }
 }

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -14,7 +14,7 @@ proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.2.1", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.3.0", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -11,9 +11,9 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 [dependencies]
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.12", optional = true }
 serde = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.2.1", default-features = false }
-usdt-macro = { path = "../usdt-macro", version = "0.2.1", default-features = false }
-usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.2.1", default-features = false }
+usdt-impl = { path = "../usdt-impl", version = "0.3.0", default-features = false }
+usdt-macro = { path = "../usdt-macro", version = "0.3.0", default-features = false }
+usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.3.0", default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -325,6 +325,19 @@
 //! their own re-exported feature, e.g., `#![cfg_attr(feature = "probes", feature(asm))]`, and
 //! instruct developers consuming their libraries to do the same.
 //!
+//! It's important to keep in mind how Cargo unifies features, however. Specifically, if `usdt` is
+//! a dependency of two other dependencies in a package, it's possible to end up in a confusing
+//! situation. Cargo takes the _union_ of all features in such a case. Thus if one crate is built
+//! expecting to use the no-op implementation and another is built _using_ the real, `asm`-based
+//! implementation, the latter will be chosen. This can be confusing or downright dangerous. First,
+//! the former crate will fail at compile time, because the `asm!` macro will actually be emitted,
+//! but the `#![feature(asm)]` flag will not be included. More troubling, the probes will actually
+//! exist in the resulting object file, even if the user specifically opted to not use them.
+//!
+//! To handle this, library writers should place _all_ references to `usdt`-related code behind a
+//! conditional compilation directive. This will ensure that the crate is not even used, rather
+//! than it being used with an unexpected implementation.
+//!
 //! [dtrace]: https://illumos.org/books/dtrace/preface.html#preface
 //! [dtrace-usdt]: https://illumos.org/books/dtrace/chp-usdt.html#chp-usdt
 //! [dtrace-json]: https://sysmgr.org/blog/2012/11/29/dtrace_and_json_together_at_last/

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -144,7 +144,7 @@
 //! ```ignore
 //! #[usdt::provider(provider = "foo")]
 //! mod probes {
-//!     fn bar() {
+//!     fn bar() {}
 //! }
 //! ```
 //!
@@ -166,6 +166,23 @@
 //! This probe `bar` will appear in DTrace as `foo:::bar`, but will now be accessible in Rust via
 //! the macro `probes::bar!`. Note that it's not possible to rename the provider as it appears in
 //! DTrace when using the builder version.
+//!
+//! Double-underscores
+//! ------------------
+//!
+//! It's a DTrace convention to name probes with dashes between words, rather than underscores. So
+//! the probe should be `my-probe` rather than `my_probe`. The former is not a valid Rust
+//! identifier, but can be achieved by using _two_ underscores in the provider or probe name. This
+//! crate internally translates `__` into `-` in such cases. For example, the provider:
+//!
+//! ```ignore
+//! #[usdt::provider("my__provider")]
+//! mod probes {
+//!     fn my__probe() {};
+//! }
+//! ```
+//!
+//! will result in a provider and probe name of `my-provider` and `my-probe`.
 //!
 //! Examples
 //! --------


### PR DESCRIPTION
- Any `__` in provider or probe names is now translated into `-`, inline
  with how DTrace probes are renamed in C, and to support the
  convention.
- Small doc fixes