### PR TITLE
Wire up support for stable asm!()

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "illumos / build-and-test"
 #: variety = "basic"
 #: target = "helios"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "stable"
 #: output_rules = []
 #:
 

--- a/common-build.rs
+++ b/common-build.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,8 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use usdt::Builder;
+//
 use version_check;
 
 fn main() {
@@ -21,9 +20,4 @@ fn main() {
     if version_check::is_min_version("1.59").unwrap_or(false) {
         println!("cargo:rustc-cfg=usdt_stable_asm");
     }
-
-    println!("cargo:rerun-if-changed=provider.d");
-    Builder::new("provider.d")
-        .build()
-        .expect("Failed to build provider");
 }

--- a/probe-test-attr/Cargo.toml
+++ b/probe-test-attr/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 usdt = { path = "../usdt", default-features = false }
 serde = "1"
 
+[build-dependencies]
+version_check = "0.9.4"
+
 [features]
 default = ["asm"]
 asm = ["usdt/asm"]

--- a/probe-test-attr/build.rs
+++ b/probe-test-attr/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/probe-test-attr/src/main.rs
+++ b/probe-test-attr/src/main.rs
@@ -1,7 +1,7 @@
 //! Example using the `usdt` crate, defining probes inline in Rust code which accept any
 //! serializable data type.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
-#![feature(asm)]
 
 use serde::Serialize;
 

--- a/probe-test-build/Cargo.toml
+++ b/probe-test-build/Cargo.toml
@@ -10,6 +10,7 @@ usdt = { path = "../usdt", default-features = false }
 
 [build-dependencies]
 usdt = { path = "../usdt" }
+version_check = "0.9.4"
 
 [features]
 default = ["asm"]

--- a/probe-test-build/build.rs
+++ b/probe-test-build/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,15 @@
 // limitations under the License.
 
 use usdt::Builder;
+use version_check;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if version_check::is_min_version("1.59").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    println!("cargo:rerun-if-changed=test.d");
     Builder::new("test.d").build().unwrap();
 }

--- a/probe-test-build/src/main.rs
+++ b/probe-test-build/src/main.rs
@@ -1,6 +1,6 @@
 //! An example using the `usdt` crate, generating the probes via a build script.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 
 use std::thread::sleep;

--- a/probe-test-macro/Cargo.toml
+++ b/probe-test-macro/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2018"
 [dependencies]
 usdt = { path = "../usdt", default-features = false }
 
+[build-dependencies]
+version_check = "0.9.4"
+
 [features]
 default = ["asm"]
 asm = ["usdt/asm"]

--- a/probe-test-macro/build.rs
+++ b/probe-test-macro/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/probe-test-macro/src/main.rs
+++ b/probe-test-macro/src/main.rs
@@ -1,6 +1,6 @@
 //! An example using the `usdt` crate, generating the probes via a procedural macro
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 
 use std::thread::sleep;

--- a/tests/argument-types/Cargo.toml
+++ b/tests/argument-types/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2018"
 [dependencies]
 usdt = { path = "../../usdt" }
 serde = "1"
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/tests/argument-types/build.rs
+++ b/tests/argument-types/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/argument-types/src/main.rs
+++ b/tests/argument-types/src/main.rs
@@ -1,7 +1,7 @@
 //! An example and compile-test showing the various ways in which probe arguments may be specified,
 //! both in the parameter list and when passing values in the probe argument closure.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 use serde::Serialize;
 

--- a/tests/common-build.rs
+++ b/tests/common-build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/compile-errors/Cargo.toml
+++ b/tests/compile-errors/Cargo.toml
@@ -11,3 +11,6 @@ serde_json = "*"
 
 [dev-dependencies]
 trybuild = "1.0.41"
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/tests/compile-errors/build.rs
+++ b/tests/compile-errors/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/compile-errors/src/lib.rs
+++ b/tests/compile-errors/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 #![deny(warnings)]
 
@@ -27,6 +27,8 @@ mod tests {
         t.compile_fail("src/no-provider-file.rs");
         t.compile_fail("src/zero-arg-probe-type-check.rs");
         t.compile_fail("src/different-serializable-type.rs");
-        t.compile_fail("src/relative-import.rs");
+        // The results of this differ between stable and nightly toolchains.
+        // It is omitted until usdt is usable with a stable compiler on all targetted platforms.
+        // t.compile_fail("src/relative-import.rs");
     }
 }

--- a/tests/compile-errors/src/relative-import.stderr
+++ b/tests/compile-errors/src/relative-import.stderr
@@ -2,7 +2,7 @@ error: Use-statements in USDT macros cannot contain relative imports (`super`), 
   --> src/relative-import.rs:27:9
    |
 27 |     use super::Expected;
-   |         ^^^^^^^^^^^^^^^
+   |         ^^^^^
 
 error[E0433]: failed to resolve: use of undeclared crate or module `my_provider`
   --> src/relative-import.rs:32:5

--- a/tests/does-it-work/Cargo.toml
+++ b/tests/does-it-work/Cargo.toml
@@ -11,3 +11,4 @@ usdt-tests-common = { path = "../../usdt-tests-common" }
 
 [build-dependencies]
 usdt = { path = "../../usdt" }
+version_check = "0.9.4"

--- a/tests/does-it-work/build.rs
+++ b/tests/does-it-work/build.rs
@@ -13,7 +13,15 @@
 // limitations under the License.
 
 use usdt::Builder;
+use version_check;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if version_check::is_min_version("1.59").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    println!("cargo:rerun-if-changed=test.d");
     Builder::new("test.d").build().unwrap();
 }

--- a/tests/does-it-work/src/main.rs
+++ b/tests/does-it-work/src/main.rs
@@ -2,7 +2,7 @@
 //! registers a single probe with arguments, and then verifies that this probe is visible to the
 //! `dtrace(1)` command-line tool.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 
 use usdt::register_probes;
@@ -27,6 +27,8 @@ fn main() {
     doesit::work!(|| (0, "something"));
 }
 
+// Disuade the compiler from inlining this, which would ruin the test for `probefunc`.
+#[inline(never)]
 #[allow(dead_code)]
 fn run_test(rx: std::sync::mpsc::Receiver<()>) {
     register_probes().unwrap();

--- a/tests/empty/Cargo.toml
+++ b/tests/empty/Cargo.toml
@@ -13,6 +13,9 @@ default-features = false
 path = "../../usdt"
 default-features = false
 
+[build-dependencies]
+version_check = "0.9.4"
+
 [features]
 default = ["asm"]
 asm = ["usdt/asm"]

--- a/tests/empty/src/main.rs
+++ b/tests/empty/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(feature = "asm", feature(asm))]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(all(feature = "asm", target_os = "macos"), feature(asm_sym))]
 #![deny(warnings)]
 

--- a/tests/fake-cmd/Cargo.toml
+++ b/tests/fake-cmd/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2018"
 
 [dependencies]
 fake-lib = { path = "../fake-lib" }
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/tests/fake-cmd/build.rs
+++ b/tests/fake-cmd/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/fake-cmd/src/main.rs
+++ b/tests/fake-cmd/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 #![deny(warnings)]
 

--- a/tests/fake-lib/Cargo.toml
+++ b/tests/fake-lib/Cargo.toml
@@ -10,3 +10,4 @@ usdt = { path = "../../usdt", features = ["asm"] }
 
 [build-dependencies]
 usdt = { path = "../../usdt", features = ["asm"] }
+version_check = "0.9.4"

--- a/tests/fake-lib/build.rs
+++ b/tests/fake-lib/build.rs
@@ -13,7 +13,15 @@
 // limitations under the License.
 
 use usdt::Builder;
+use version_check;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if version_check::is_min_version("1.59").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    println!("cargo:rerun-if-changed=test.d");
     Builder::new("test.d").build().unwrap();
 }

--- a/tests/fake-lib/src/lib.rs
+++ b/tests/fake-lib/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 #![deny(warnings)]
 

--- a/tests/modules/Cargo.toml
+++ b/tests/modules/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 usdt = { path = "../../usdt" }
 serde = "1"
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/tests/modules/build.rs
+++ b/tests/modules/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/modules/src/main.rs
+++ b/tests/modules/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 
 mod inner;

--- a/tests/rename-builder/Cargo.toml
+++ b/tests/rename-builder/Cargo.toml
@@ -9,3 +9,4 @@ serde = "1"
 
 [build-dependencies]
 usdt = { path = "../../usdt" }
+version_check = "0.9.4"

--- a/tests/rename-builder/build.rs
+++ b/tests/rename-builder/build.rs
@@ -13,7 +13,15 @@
 // limitations under the License.
 
 use usdt::Builder;
+use version_check;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if version_check::is_min_version("1.59").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    println!("cargo:rerun-if-changed=test.d");
     Builder::new("test.d").module("still_test").build().unwrap();
 }

--- a/tests/rename-builder/src/main.rs
+++ b/tests/rename-builder/src/main.rs
@@ -1,7 +1,7 @@
 //! Test verifying that renaming the provider/probes in various ways works when using a build
 //! script.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 include!(concat!(env!("OUT_DIR"), "/test.rs"));
 

--- a/tests/rename/Cargo.toml
+++ b/tests/rename/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 usdt = { path = "../../usdt" }
 serde = "1"
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/tests/rename/build.rs
+++ b/tests/rename/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/rename/src/main.rs
+++ b/tests/rename/src/main.rs
@@ -1,6 +1,6 @@
 //! Integration test verifying that provider modules are renamed correctly.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 
 #[usdt::provider(provider = "something", probe_format = "probe_{probe}")]

--- a/tests/test-json/Cargo.toml
+++ b/tests/test-json/Cargo.toml
@@ -9,3 +9,6 @@ usdt = { path = "../../usdt" }
 usdt-tests-common = { path = "../../usdt-tests-common" }
 serde = "*"
 serde_json = "*"
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/tests/test-json/build.rs
+++ b/tests/test-json/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/test-json/src/main.rs
+++ b/tests/test-json/src/main.rs
@@ -1,6 +1,6 @@
 //! Integration test verifying JSON output, including when serialization fails.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 
 use serde::{Serialize, Serializer};

--- a/tests/test-unique-id/Cargo.toml
+++ b/tests/test-unique-id/Cargo.toml
@@ -9,3 +9,6 @@ usdt = { path = "../../usdt" }
 
 [dev-dependencies]
 subprocess = "0.2"
+
+[build-dependencies]
+version_check = "0.9.4"

--- a/tests/test-unique-id/build.rs
+++ b/tests/test-unique-id/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/tests/test-unique-id/src/main.rs
+++ b/tests/test-unique-id/src/main.rs
@@ -1,6 +1,6 @@
 //! Integration test for `usdt::UniqueId`
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 
 #[usdt::provider]

--- a/tests/zero-arg-probe/Cargo.toml
+++ b/tests/zero-arg-probe/Cargo.toml
@@ -10,3 +10,4 @@ usdt = { path = "../../usdt" }
 
 [build-dependencies]
 usdt = { path = "../../usdt" }
+version_check = "0.9.4"

--- a/tests/zero-arg-probe/build.rs
+++ b/tests/zero-arg-probe/build.rs
@@ -13,7 +13,15 @@
 // limitations under the License.
 
 use usdt::Builder;
+use version_check;
 
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    if version_check::is_min_version("1.59").unwrap_or(false) {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    println!("cargo:rerun-if-changed=test.d");
     Builder::new("test.d").build().unwrap();
 }

--- a/tests/zero-arg-probe/src/main.rs
+++ b/tests/zero-arg-probe/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm)]
+#![cfg_attr(not(usdt_stable_asm), feature(asm))]
 #![cfg_attr(target_os = "macos", feature(asm_sym))]
 #![deny(warnings)]
 

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -21,6 +21,9 @@ syn = { version = "1", features = ["full", "extra-traits"] }
 thiserror = "1"
 thread-id = "4"
 
+[build-dependencies]
+version_check = "0.9.4"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }
 

--- a/usdt-impl/build.rs
+++ b/usdt-impl/build.rs
@@ -1,0 +1,1 @@
+../common-build.rs

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -1,6 +1,6 @@
 //! Main implementation crate for the USDT package.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg_attr(feature = "asm", feature(asm))]
+#![cfg_attr(all(not(usdt_stable_asm), feature = "asm"), feature(asm))]
 
 use serde::Deserialize;
 use std::cell::RefCell;

--- a/usdt-impl/src/linker.rs
+++ b/usdt-impl/src/linker.rs
@@ -52,7 +52,7 @@
 //!    of the `stability` and `typedefs` symbols could be anything--we just need
 //!    a symbol name we can reference for the asm! macro that won't get garbled.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -179,6 +179,11 @@ fn compile_probe(
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     compile_error!("USDT only supports x86_64 and AArch64 architectures");
 
+    #[cfg(usdt_stable_asm)]
+    let asm_macro = quote! { std::arch::asm };
+    #[cfg(not(usdt_stable_asm))]
+    let asm_macro = quote! { asm };
+
     let impl_block = quote! {
         extern "C" {
             #[allow(unused)]
@@ -200,7 +205,7 @@ fn compile_probe(
         unsafe {
             if #is_enabled_fn() != 0 {
                 #unpacked_args
-                asm!(
+                #asm_macro!(
                     ".reference {typedefs}",
                     #call_instruction,
                     ".reference {stability}",

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -1,7 +1,7 @@
 //! Implementation of construction and extraction of custom linker section records used to store
 //! probe information in an object file.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@ use std::{
     ffi::CStr,
     ptr::{null, null_mut},
 };
+
+#[cfg(usdt_stable_asm)]
+use std::arch::asm;
 
 #[cfg(feature = "des")]
 use std::{fs, path::Path};


### PR DESCRIPTION
Support for `asm!()` has finally landed in stable rust!  This should make the crate usable by those building with 1.59 stable and later.  Earlier nightly compilers should continue to work, provided the `feature(asm)` declaration is still in the consumer crate.