### PR TITLE
Add support for const pointers to integer types

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ provider my_provider {
 ```
 
 This script defines a single provider, `test`, with two probes, `start` and `stop`,
-with a different set of arguments. (Numeric primitive types, pointers to numeric primitives,
-and `&str`s are currently supported.)
+with a different set of arguments. (Integral primitive types, pointers to
+integral types, and `&str`s are currently supported. Note that `char*` is used
+to indicate Rust-style UTF-8 strings. If you'd like a byte array, use `uint8_t*`
+or `int8_t*`.)
 
 This provider definition must be converted into Rust code, which can be done in a simple
 build script:

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ provider my_provider {
 ```
 
 This script defines a single provider, `test`, with two probes, `start` and `stop`,
-with a different set of arguments. (Numeric primitive types and `&str`s are currently
-supported.)
+with a different set of arguments. (Numeric primitive types, pointers to numeric primitives,
+and `&str`s are currently supported.)
 
 This provider definition must be converted into Rust code, which can be done in a simple
 build script:

--- a/dtrace-parser/src/dtrace.pest
+++ b/dtrace-parser/src/dtrace.pest
@@ -17,9 +17,8 @@ IDENTIFIER = @{ ASCII_ALPHA+ ~ (ASCII_ALPHANUMERIC | "_")* }
 BIT_WIDTH = @{ "8" | "16" | "32" | "64" }
 SIGNED_INT = ${ "int" ~ BIT_WIDTH ~ "_t" }
 UNSIGNED_INT = ${ "uint" ~ BIT_WIDTH ~ "_t" }
-INT = $ { SIGNED_INT | UNSIGNED_INT }
 STAR = ${ "*" }
-INTEGER = ${ (INT ~ STAR) | INT }
+INTEGER = ${ ((SIGNED_INT | UNSIGNED_INT) ~ STAR) | (SIGNED_INT | UNSIGNED_INT) }
 STRING = { "char" ~ STAR }
 DATA_TYPE = { INTEGER | STRING }
 

--- a/dtrace-parser/src/dtrace.pest
+++ b/dtrace-parser/src/dtrace.pest
@@ -1,5 +1,5 @@
 // A definition of the basic grammar of DTrace provider definitions.
-// Copyright 2021 Oxide Computer Company
+// Copyright 2022 Oxide Computer Company
 
 // Some basic tokens
 PROBE_KEY = @{ "probe" }
@@ -17,8 +17,11 @@ IDENTIFIER = @{ ASCII_ALPHA+ ~ (ASCII_ALPHANUMERIC | "_")* }
 BIT_WIDTH = @{ "8" | "16" | "32" | "64" }
 SIGNED_INT = ${ "int" ~ BIT_WIDTH ~ "_t" }
 UNSIGNED_INT = ${ "uint" ~ BIT_WIDTH ~ "_t" }
-STRING = { "char" ~ "*" }
-DATA_TYPE = { STRING | UNSIGNED_INT | SIGNED_INT}
+INT = $ { SIGNED_INT | UNSIGNED_INT }
+STAR = ${ "*" }
+INTEGER = ${ (INT ~ STAR) | INT }
+STRING = { "char" ~ STAR }
+DATA_TYPE = { INTEGER | STRING }
 
 // A list of probe arguments, which are just data types
 ARGUMENT_LIST = { ( DATA_TYPE ~ ("," ~ DATA_TYPE)* )* }

--- a/dtrace-parser/src/dtrace.pest
+++ b/dtrace-parser/src/dtrace.pest
@@ -17,10 +17,11 @@ IDENTIFIER = @{ ASCII_ALPHA+ ~ (ASCII_ALPHANUMERIC | "_")* }
 BIT_WIDTH = @{ "8" | "16" | "32" | "64" }
 SIGNED_INT = ${ "int" ~ BIT_WIDTH ~ "_t" }
 UNSIGNED_INT = ${ "uint" ~ BIT_WIDTH ~ "_t" }
+INTEGER = ${ (SIGNED_INT | UNSIGNED_INT) }
 STAR = ${ "*" }
-INTEGER = ${ ((SIGNED_INT | UNSIGNED_INT) ~ STAR) | (SIGNED_INT | UNSIGNED_INT) }
+INTEGER_POINTER = ${ INTEGER ~ STAR }
 STRING = { "char" ~ STAR }
-DATA_TYPE = { INTEGER | STRING }
+DATA_TYPE = { INTEGER_POINTER | INTEGER | STRING }
 
 // A list of probe arguments, which are just data types
 ARGUMENT_LIST = { ( DATA_TYPE ~ ("," ~ DATA_TYPE)* )* }

--- a/dtrace-parser/src/lib.rs
+++ b/dtrace-parser/src/lib.rs
@@ -158,22 +158,20 @@ impl TryFrom<&Pair<'_, Rule>> for DataType {
                     .next()
                     .expect("Expected a signed or unsigned integer or pointer to one");
                 assert!(matches!(integer.as_rule(), Rule::INTEGER));
-
                 let mut integer = integer.clone().into_inner();
-                let integer_type = integer.next().unwrap().into_inner().next().unwrap();
+                let integer_type = integer.next().unwrap();
                 let pointer = integer.next().is_some();
-
                 let sign = match integer_type.as_rule() {
                     Rule::SIGNED_INT => Sign::Signed,
                     Rule::UNSIGNED_INT => Sign::Unsigned,
-                    _ => unreachable!(),
+                    _ => unreachable!("Expected a signed or unsigned integer"),
                 };
                 let width = match integer_type.into_inner().as_str() {
                     "8" => BitWidth::Bit8,
                     "16" => BitWidth::Bit16,
                     "32" => BitWidth::Bit32,
                     "64" => BitWidth::Bit64,
-                    _ => unreachable!(),
+                    _ => unreachable!("Expected a bit width"),
                 };
                 DataType::Integer(Integer {
                     sign,

--- a/dtrace-parser/src/lib.rs
+++ b/dtrace-parser/src/lib.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashSet;
 use std::convert::TryFrom;
+use std::fmt;
 use std::fs;
 use std::path::Path;
 
@@ -60,17 +61,83 @@ fn expect_token(pair: &Pair<'_, Rule>, rule: Rule) -> Result<(), DTraceError> {
     }
 }
 
+/// The bit-width of an integer data type
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BitWidth {
+    Bit8,
+    Bit16,
+    Bit32,
+    Bit64,
+}
+
+impl fmt::Display for BitWidth {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let w = match self {
+            BitWidth::Bit8 => "8",
+            BitWidth::Bit16 => "16",
+            BitWidth::Bit32 => "32",
+            BitWidth::Bit64 => "64",
+        };
+        write!(f, "{}", w)
+    }
+}
+
+/// The signed-ness of an integer data type
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Sign {
+    Signed,
+    Unsigned,
+}
+
+/// An integer data type
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Integer {
+    pub sign: Sign,
+    pub width: BitWidth,
+    pub pointer: bool,
+}
+
+const RUST_TYPE_PREFIX: &str = "::std::os::raw::c_";
+
+impl Integer {
+    pub fn to_c_type(&self) -> String {
+        let prefix = match self.sign {
+            Sign::Unsigned => "u",
+            _ => "",
+        };
+        let star = if self.pointer { "*" } else { "" };
+        format!("{prefix}int{}_t{star}", self.width)
+    }
+
+    pub fn to_rust_ffi_type(&self) -> String {
+        let ty = match (self.sign, self.width) {
+            (Sign::Unsigned, BitWidth::Bit8) => "uchar",
+            (Sign::Unsigned, BitWidth::Bit16) => "ushort",
+            (Sign::Unsigned, BitWidth::Bit32) => "uint",
+            (Sign::Unsigned, BitWidth::Bit64) => "ulonglong",
+            (Sign::Signed, BitWidth::Bit8) => "schar",
+            (Sign::Signed, BitWidth::Bit16) => "short",
+            (Sign::Signed, BitWidth::Bit32) => "int",
+            (Sign::Signed, BitWidth::Bit64) => "longlong",
+        };
+        let star = if self.pointer { "*const " } else { "" };
+        format!("{star}{RUST_TYPE_PREFIX}{ty}")
+    }
+
+    pub fn to_rust_type(&self) -> String {
+        let prefix = match self.sign {
+            Sign::Signed => "i",
+            Sign::Unsigned => "u",
+        };
+        let star = if self.pointer { "*const " } else { "" };
+        format!("{star}{prefix}{}", self.width)
+    }
+}
+
 /// Represents the data type of a single probe argument.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DataType {
-    U8,
-    U16,
-    U32,
-    U64,
-    I8,
-    I16,
-    I32,
-    I64,
+    Integer(Integer),
     String,
 }
 
@@ -85,20 +152,35 @@ impl TryFrom<&Pair<'_, Rule>> for DataType {
             .next()
             .expect("Data type token is expected to contain a concrete type");
         let typ = match inner.as_rule() {
-            Rule::UNSIGNED_INT => match inner.into_inner().as_str() {
-                "8" => DataType::U8,
-                "16" => DataType::U16,
-                "32" => DataType::U32,
-                "64" => DataType::U64,
-                _ => unreachable!(),
-            },
-            Rule::SIGNED_INT => match inner.into_inner().as_str() {
-                "8" => DataType::I8,
-                "16" => DataType::I16,
-                "32" => DataType::I32,
-                "64" => DataType::I64,
-                _ => unreachable!(),
-            },
+            Rule::INTEGER => {
+                let mut pairs = pair.clone().into_inner();
+                let integer = pairs
+                    .next()
+                    .expect("Expected a signed or unsigned integer or pointer to one");
+                assert!(matches!(integer.as_rule(), Rule::INTEGER));
+
+                let mut integer = integer.clone().into_inner();
+                let integer_type = integer.next().unwrap().into_inner().next().unwrap();
+                let pointer = integer.next().is_some();
+
+                let sign = match integer_type.as_rule() {
+                    Rule::SIGNED_INT => Sign::Signed,
+                    Rule::UNSIGNED_INT => Sign::Unsigned,
+                    _ => unreachable!(),
+                };
+                let width = match integer_type.into_inner().as_str() {
+                    "8" => BitWidth::Bit8,
+                    "16" => BitWidth::Bit16,
+                    "32" => BitWidth::Bit32,
+                    "64" => BitWidth::Bit64,
+                    _ => unreachable!(),
+                };
+                DataType::Integer(Integer {
+                    sign,
+                    width,
+                    pointer,
+                })
+            }
             Rule::STRING => DataType::String,
             _ => unreachable!("Parsed an unexpected DATA_TYPE token"),
         };
@@ -118,49 +200,25 @@ impl DataType {
     /// Convert a type into its C type represenation as a string
     pub fn to_c_type(&self) -> String {
         match self {
-            DataType::U8 => "uint8_t",
-            DataType::U16 => "uint16_t",
-            DataType::U32 => "uint32_t",
-            DataType::U64 => "uint64_t",
-            DataType::I8 => "int8_t",
-            DataType::I16 => "int16_t",
-            DataType::I32 => "int32_t",
-            DataType::I64 => "int64_t",
-            DataType::String => "char*",
+            DataType::Integer(int) => int.to_c_type(),
+            DataType::String => String::from("char*"),
         }
-        .into()
     }
 
     /// Return the Rust FFI type representation of this data type
     pub fn to_rust_ffi_type(&self) -> String {
         match self {
-            DataType::U8 => "::std::os::raw::c_uchar",
-            DataType::U16 => "::std::os::raw::c_ushort",
-            DataType::U32 => "::std::os::raw::c_uint",
-            DataType::U64 => "::std::os::raw::c_ulonglong",
-            DataType::I8 => "::std::os::raw::c_schar",
-            DataType::I16 => "::std::os::raw::c_short",
-            DataType::I32 => "::std::os::raw::c_int",
-            DataType::I64 => "::std::os::raw::c_longlong",
-            DataType::String => "*const ::std::os::raw::c_char",
+            DataType::Integer(int) => int.to_rust_ffi_type(),
+            DataType::String => format!("*const {RUST_TYPE_PREFIX}char"),
         }
-        .into()
     }
 
     /// Return the native Rust type representation of this data type
     pub fn to_rust_type(&self) -> String {
         match self {
-            DataType::U8 => "u8",
-            DataType::U16 => "u16",
-            DataType::U32 => "u32",
-            DataType::U64 => "u64",
-            DataType::I8 => "i8",
-            DataType::I16 => "i16",
-            DataType::I32 => "i32",
-            DataType::I64 => "i64",
-            DataType::String => "&str",
+            DataType::Integer(int) => int.to_rust_type(),
+            DataType::String => String::from("&str"),
         }
-        .into()
     }
 }
 
@@ -375,7 +433,16 @@ impl TryFrom<&str> for File {
 
 #[cfg(test)]
 mod tests {
-    use super::{DTraceParser, DataType, File, Probe, Provider, Rule, TryFrom};
+    use super::BitWidth;
+    use super::DTraceParser;
+    use super::DataType;
+    use super::File;
+    use super::Integer;
+    use super::Probe;
+    use super::Provider;
+    use super::Rule;
+    use super::Sign;
+    use super::TryFrom;
     use ::pest::Parser;
     use rstest::{fixture, rstest};
 
@@ -486,14 +553,22 @@ mod tests {
     #[rstest(
         defn,
         data_type,
-        case("uint8_t", DataType::U8),
-        case("uint16_t", DataType::U16),
-        case("uint32_t", DataType::U32),
-        case("uint64_t", DataType::U64),
-        case("int8_t", DataType::I8),
-        case("int16_t", DataType::I16),
-        case("int32_t", DataType::I32),
-        case("int64_t", DataType::I64),
+        case("uint8_t", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8, pointer: false })),
+        case("uint16_t", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit16, pointer: false })),
+        case("uint32_t", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit32, pointer: false })),
+        case("uint64_t", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit64, pointer: false })),
+        case("int8_t", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit8, pointer: false })),
+        case("int16_t", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit16, pointer: false })),
+        case("int32_t", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit32, pointer: false })),
+        case("int64_t", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit64, pointer: false })),
+        case("uint8_t*", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8, pointer: true })),
+        case("uint16_t*", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit16, pointer: true })),
+        case("uint32_t*", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit32, pointer: true })),
+        case("uint64_t*", DataType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit64, pointer: true })),
+        case("int8_t*", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit8, pointer: true })),
+        case("int16_t*", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit16, pointer: true })),
+        case("int32_t*", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit32, pointer: true })),
+        case("int64_t*", DataType::Integer(Integer { sign: Sign::Signed, width: BitWidth::Bit64, pointer: true })),
         case("char*", DataType::String)
     )]
     fn test_data_type_enum(defn: &str, data_type: DataType) {
@@ -512,7 +587,7 @@ mod tests {
     #[fixture]
     fn probe_data() -> (String, String) {
         let provider = String::from("foo");
-        let probe = String::from("probe baz(char*, uint16_t, uint8_t);");
+        let probe = String::from("probe baz(char*, uint16_t, uint8_t*);");
         (provider, probe)
     }
 
@@ -532,7 +607,19 @@ mod tests {
         assert_eq!(probe.name, "baz");
         assert_eq!(
             probe.types,
-            &[DataType::String, DataType::U16, DataType::U8]
+            &[
+                DataType::String,
+                DataType::Integer(Integer {
+                    sign: Sign::Unsigned,
+                    width: BitWidth::Bit16,
+                    pointer: false
+                }),
+                DataType::Integer(Integer {
+                    sign: Sign::Unsigned,
+                    width: BitWidth::Bit8,
+                    pointer: true
+                }),
+            ]
         );
     }
 

--- a/probe-test-attr/src/main.rs
+++ b/probe-test-attr/src/main.rs
@@ -82,6 +82,9 @@ mod test {
     /// Some types aren't JSON serializable. These will not break the program, but an error message
     /// will be seen in DTrace.
     fn not_json_serializable(_: crate::Whoops) {}
+
+    /// Constant pointers to integer types are also supported
+    fn work_with_pointer(_buffer: *const u8, _: u64) {}
 }
 
 fn main() {
@@ -90,6 +93,7 @@ fn main() {
         x: 0,
         buffer: vec![1; 12],
     };
+    let buffer = vec![2; 4];
     loop {
         test::start_work!(|| arg.x);
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -104,5 +108,6 @@ fn main() {
         });
         test::arg_as_tuple!(|| (arg.x, &arg.buffer[..]));
         test::not_json_serializable!(|| Whoops::NoBueno(0));
+        test::work_with_pointer!(|| (buffer.as_ptr(), buffer.len() as u64));
     }
 }

--- a/usdt-attr-macro/src/lib.rs
+++ b/usdt-attr-macro/src/lib.rs
@@ -239,7 +239,7 @@ fn parse_probe_argument(
             item.span(),
             concat!(
                 "Probe arguments must be path types, slices, arrays, tuples, ",
-                "references, or const pointers to integers ",
+                "references, or const pointers to integers",
             ),
         )),
     }

--- a/usdt-attr-macro/src/lib.rs
+++ b/usdt-attr-macro/src/lib.rs
@@ -309,53 +309,51 @@ fn data_type_from_path(path: &syn::Path, pointer: bool) -> DataType {
     use dtrace_parser::Integer;
     use dtrace_parser::Sign;
 
+    let variant = if pointer {
+        DType::Pointer
+    } else {
+        DType::Integer
+    };
+
     if path.is_ident("u8") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Unsigned,
             width: BitWidth::Bit8,
-            pointer,
         }))
     } else if path.is_ident("u16") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Unsigned,
             width: BitWidth::Bit16,
-            pointer,
         }))
     } else if path.is_ident("u32") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Unsigned,
             width: BitWidth::Bit32,
-            pointer,
         }))
     } else if path.is_ident("u64") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Unsigned,
             width: BitWidth::Bit64,
-            pointer,
         }))
     } else if path.is_ident("i8") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Signed,
             width: BitWidth::Bit8,
-            pointer,
         }))
     } else if path.is_ident("i16") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Signed,
             width: BitWidth::Bit16,
-            pointer,
         }))
     } else if path.is_ident("i32") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Signed,
             width: BitWidth::Bit32,
-            pointer,
         }))
     } else if path.is_ident("i64") {
-        DataType::Native(DType::Integer(Integer {
+        DataType::Native(variant(Integer {
             sign: Sign::Signed,
             width: BitWidth::Bit64,
-            pointer,
         }))
     } else if path.is_ident("String") || path.is_ident("str") {
         DataType::Native(DType::String)
@@ -415,15 +413,13 @@ mod tests {
             DataType::Native(DType::Integer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: false
             })),
         );
         assert_eq!(
             data_type_from_path(&syn::parse_str("u8").unwrap(), true),
-            DataType::Native(DType::Integer(Integer {
+            DataType::Native(DType::Pointer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: true
             })),
         );
         assert_eq!(
@@ -443,9 +439,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case("u8", DType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8, pointer: false }))]
-    #[case("*const u8", DType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8, pointer: true }))]
-    #[case("&u8", DType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8, pointer: false }))]
+    #[case("u8", DType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8 }))]
+    #[case("*const u8", DType::Pointer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8}))]
+    #[case("&u8", DType::Integer(Integer { sign: Sign::Unsigned, width: BitWidth::Bit8 }))]
     #[case("&str", DType::String)]
     #[case("String", DType::String)]
     #[case("&&str", DType::String)]

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -283,12 +283,10 @@ mod tests {
             DataType::Native(DType::Integer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: false,
             })),
             DataType::Native(DType::Integer(Integer {
                 sign: Sign::Signed,
                 width: BitWidth::Bit64,
-                pointer: false,
             })),
         ];
         let expected = quote! {
@@ -372,10 +370,9 @@ mod tests {
     #[test]
     fn test_construct_probe_args() {
         let types = &[
-            DataType::Native(DType::Integer(Integer {
+            DataType::Native(DType::Pointer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: true,
             })),
             DataType::Native(dtrace_parser::DataType::String),
         ];
@@ -406,7 +403,6 @@ mod tests {
             &DataType::Native(DType::Integer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: false,
             })),
             TokenStream::from_str("foo").unwrap(),
         );

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -257,6 +257,10 @@ pub(crate) fn build_probe_macro(
 mod tests {
 
     use super::*;
+    use dtrace_parser::BitWidth;
+    use dtrace_parser::DataType as DType;
+    use dtrace_parser::Integer;
+    use dtrace_parser::Sign;
 
     #[test]
     fn test_generate_type_check_empty() {
@@ -276,8 +280,16 @@ mod tests {
         let provider = "provider";
         let probe = "probe";
         let types = &[
-            DataType::Native(dtrace_parser::DataType::U8),
-            DataType::Native(dtrace_parser::DataType::I64),
+            DataType::Native(DType::Integer(Integer {
+                sign: Sign::Unsigned,
+                width: BitWidth::Bit8,
+                pointer: false,
+            })),
+            DataType::Native(DType::Integer(Integer {
+                sign: Sign::Signed,
+                width: BitWidth::Bit64,
+                pointer: false,
+            })),
         ];
         let expected = quote! {
             let __usdt_private_args_lambda = $args_lambda;
@@ -360,14 +372,18 @@ mod tests {
     #[test]
     fn test_construct_probe_args() {
         let types = &[
-            DataType::Native(dtrace_parser::DataType::U8),
+            DataType::Native(DType::Integer(Integer {
+                sign: Sign::Unsigned,
+                width: BitWidth::Bit8,
+                pointer: true,
+            })),
             DataType::Native(dtrace_parser::DataType::String),
         ];
         let registers = &["rdi", "rsi"];
         let (args, regs) = construct_probe_args(types);
         let expected = quote! {
             let args = __usdt_private_args_lambda();
-            let arg_0 = (*<_ as ::std::borrow::Borrow<u8>>::borrow(&args.0) as i64);
+            let arg_0 = (*<_ as ::std::borrow::Borrow<*const u8>>::borrow(&args.0) as i64);
             let arg_1 = [(args.1.as_ref() as &str).as_bytes(), &[0_u8]].concat();
         };
         assert_eq!(args.to_string(), expected.to_string());
@@ -387,7 +403,11 @@ mod tests {
     fn test_asm_type_convert() {
         use std::str::FromStr;
         let (out, post) = asm_type_convert(
-            &DataType::Native(dtrace_parser::DataType::U8),
+            &DataType::Native(DType::Integer(Integer {
+                sign: Sign::Unsigned,
+                width: BitWidth::Bit8,
+                pointer: false,
+            })),
             TokenStream::from_str("foo").unwrap(),
         );
         assert_eq!(

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -439,21 +439,33 @@ impl Clone for UniqueId {
 #[cfg(test)]
 mod test {
     use super::*;
+    use dtrace_parser::BitWidth;
+    use dtrace_parser::DataType as DType;
+    use dtrace_parser::Integer;
+    use dtrace_parser::Sign;
 
     #[test]
     fn test_probe_to_d_source() {
         let probe = Probe {
             name: String::from("my_probe"),
-            types: vec![DataType::Native(dtrace_parser::DataType::U8)],
+            types: vec![DataType::Native(DType::Integer(Integer {
+                sign: Sign::Unsigned,
+                width: BitWidth::Bit8,
+                pointer: true,
+            }))],
         };
-        assert_eq!(probe.to_d_source(), "probe my_probe(uint8_t);");
+        assert_eq!(probe.to_d_source(), "probe my_probe(uint8_t*);");
     }
 
     #[test]
     fn test_provider_to_d_source() {
         let probe = Probe {
             name: String::from("my_probe"),
-            types: vec![DataType::Native(dtrace_parser::DataType::U8)],
+            types: vec![DataType::Native(DType::Integer(Integer {
+                sign: Sign::Unsigned,
+                width: BitWidth::Bit8,
+                pointer: false,
+            }))],
         };
         let provider = Provider {
             name: String::from("my_provider"),
@@ -468,8 +480,12 @@ mod test {
 
     #[test]
     fn test_data_type() {
-        let ty = DataType::Native(dtrace_parser::DataType::U8);
-        assert_eq!(ty.to_rust_type(), syn::parse_str("u8").unwrap());
+        let ty = DataType::Native(DType::Integer(Integer {
+            sign: Sign::Unsigned,
+            width: BitWidth::Bit8,
+            pointer: true,
+        }));
+        assert_eq!(ty.to_rust_type(), syn::parse_str("*const u8").unwrap());
 
         let ty = DataType::Native(dtrace_parser::DataType::String);
         assert_eq!(ty.to_rust_type(), syn::parse_str("&str").unwrap());

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -448,10 +448,9 @@ mod test {
     fn test_probe_to_d_source() {
         let probe = Probe {
             name: String::from("my_probe"),
-            types: vec![DataType::Native(DType::Integer(Integer {
+            types: vec![DataType::Native(DType::Pointer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: true,
             }))],
         };
         assert_eq!(probe.to_d_source(), "probe my_probe(uint8_t*);");
@@ -464,7 +463,6 @@ mod test {
             types: vec![DataType::Native(DType::Integer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: false,
             }))],
         };
         let provider = Provider {
@@ -480,10 +478,9 @@ mod test {
 
     #[test]
     fn test_data_type() {
-        let ty = DataType::Native(DType::Integer(Integer {
+        let ty = DataType::Native(DType::Pointer(Integer {
             sign: Sign::Unsigned,
             width: BitWidth::Bit8,
-            pointer: true,
         }));
         assert_eq!(ty.to_rust_type(), syn::parse_str("*const u8").unwrap());
 

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -534,10 +534,9 @@ mod test {
         let provider = "provider";
         let probe = "probe";
         let types = [
-            DataType::Native(DType::Integer(Integer {
+            DataType::Native(DType::Pointer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: true,
             })),
             DataType::Native(DType::String),
         ];
@@ -569,10 +568,9 @@ mod test {
         let provider = "provider";
         let probe = "my__probe";
         let types = [
-            DataType::Native(DType::Integer(Integer {
+            DataType::Native(DType::Pointer(Integer {
                 sign: Sign::Unsigned,
                 width: BitWidth::Bit8,
-                pointer: true,
             })),
             DataType::Native(dtrace_parser::DataType::String),
         ];

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -370,6 +370,10 @@ mod test {
     use super::DataType;
     use super::PROBE_REC_VERSION;
     use super::{MAX_PROBE_NAME_LEN, MAX_PROVIDER_NAME_LEN};
+    use dtrace_parser::BitWidth;
+    use dtrace_parser::DataType as DType;
+    use dtrace_parser::Integer;
+    use dtrace_parser::Sign;
 
     #[test]
     fn test_process_probe_record() {
@@ -530,8 +534,12 @@ mod test {
         let provider = "provider";
         let probe = "probe";
         let types = [
-            DataType::Native(dtrace_parser::DataType::U8),
-            DataType::Native(dtrace_parser::DataType::String),
+            DataType::Native(DType::Integer(Integer {
+                sign: Sign::Unsigned,
+                width: BitWidth::Bit8,
+                pointer: true,
+            })),
+            DataType::Native(DType::String),
         ];
         let record = emit_probe_record(provider, probe, Some(&types));
         let mut lines = record.lines();
@@ -561,7 +569,11 @@ mod test {
         let provider = "provider";
         let probe = "my__probe";
         let types = [
-            DataType::Native(dtrace_parser::DataType::U8),
+            DataType::Native(DType::Integer(Integer {
+                sign: Sign::Unsigned,
+                width: BitWidth::Bit8,
+                pointer: true,
+            })),
             DataType::Native(dtrace_parser::DataType::String),
         ];
         let record = emit_probe_record(provider, probe, Some(&types));

--- a/usdt-macro/src/lib.rs
+++ b/usdt-macro/src/lib.rs
@@ -68,7 +68,8 @@ use usdt_impl::compile_provider_source;
 ///
 /// Note
 /// ----
-/// The only supported types are integers of specific bit-width (e.g., `uint16_t`) and `char *`.
+/// The only supported types are integers of specific bit-width (e.g., `uint16_t`),
+/// pointers to integers, and `char *`.
 #[proc_macro]
 pub fn dtrace_provider(item: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let mut tokens = item.into_iter().collect::<Vec<proc_macro::TokenTree>>();

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -34,8 +34,9 @@
 //! names are intended to help understand the behavior of a program, so they should be semantically
 //! meaningful. Probes accept zero or more arguments, data that is associated with the probe event
 //! itself (timestamps, file descriptors, filesystem paths, etc.). The arguments may be specified
-//! as any of the exact bit-width integer types (e.g., `int16_t`) or strings (`char *`s). See
-//! [Data types](#data-types) for a full list of supported types.
+//! as any of the exact bit-width integer types (e.g., `int16_t`), pointers to
+//! such integers, or strings (`char *`s). See [Data types](#data-types) for a full list of
+//! supported types.
 //!
 //! Assuming the above is in a file called `"test.d"`, the probes may be compiled into Rust code
 //! with:
@@ -211,6 +212,7 @@
 //! Below is the full list of supported types.
 //!
 //! - `(u?)int(8|16|32|64)_t`
+//! - Pointers to the above integer types
 //! - `char *`
 //! - `T: Clone + serde::Serialize` (Only when defining probes in Rust)
 //!


### PR DESCRIPTION
- Reworks some of the internal dtrace-parser code to make integers more
  compact and easily represent pointers.
- Adds support for pointers the implementation crates
- Adds pointers to list of supported types
- Adds a probe in the `probe-test-attr` crate that uses a pointer.