### PR TITLE
More stable asm

### DIFF
--- a/common-build.rs
+++ b/common-build.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-use version_check;
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/dtrace-parser/src/lib.rs
+++ b/dtrace-parser/src/lib.rs
@@ -369,7 +369,7 @@ impl TryFrom<&Pair<'_, Rule>> for File {
     type Error = DTraceError;
 
     fn try_from(pair: &Pair<'_, Rule>) -> Result<Self, Self::Error> {
-        expect_token(&pair, Rule::FILE)?;
+        expect_token(pair, Rule::FILE)?;
         let mut providers = Vec::new();
         let mut names = HashSet::new();
         for item in pair.clone().into_inner() {

--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -7,10 +7,7 @@ description = "Tool to inspect USDT probe records in object files"
 license = "Apache-2.0"
 
 [dependencies]
-dof = { path = "../dof", version = "0.1.5", features = [ "des" ] }
+dof = { path = "../dof", features = [ "des" ] }
+goblin = { version = "0.4", features = [ "elf32", "elf64" ] }
 structopt = "0.3.21"
-
-[dependencies.usdt]
-path = "../usdt"
-version = "0.3.0"
-features = ["asm", "des"]
+usdt-impl = { path = "../usdt-impl", features = ["des"] }

--- a/dusty/src/main.rs
+++ b/dusty/src/main.rs
@@ -14,9 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::PathBuf;
+use std::fs;
+use std::path::{Path, PathBuf};
 
+use dof::Section;
+use goblin::Object;
 use structopt::StructOpt;
+use usdt_impl::Error as UsdtError;
 
 /// Inspect data related to USDT probes in object files.
 #[derive(Debug, StructOpt)]
@@ -47,10 +51,95 @@ fn main() {
     }
 
     // File contains no DOF data. Try to parse out the ASM records inserted by the `usdt` crate.
-    if let Some(data) =
-        usdt::record::extract_probe_records(&cmd.file).expect("Failed to parse probe information")
-    {
-        // TODO This could use the raw/verbose arguments, by first converting into the C structs.
-        println!("{:#?}", data)
+    match probe_records(&cmd.file) {
+        Ok(data) => {
+            // TODO This could use the raw/verbose arguments by first converting into C structs.
+            println!("{:#?}", data)
+        }
+        Err(UsdtError::InvalidFile) => {
+            println!("No probe information found");
+        }
+        Err(e) => {
+            println!("Failed to parse probe information, {:?}", e);
+        }
+    }
+}
+
+// Extract probe records from the given file, if possible.
+pub(crate) fn probe_records<P: AsRef<Path>>(file: P) -> Result<Section, UsdtError> {
+    let data = fs::read(file)?;
+    let section = locate_probe_section(&data).ok_or(UsdtError::InvalidFile)?;
+
+    usdt_impl::record::process_section(section)
+}
+
+fn locate_probe_section(data: &[u8]) -> Option<&[u8]> {
+    match Object::parse(data).ok()? {
+        Object::Elf(object) => {
+            // Try to find our special `set_dtrace_probes` section from the section headers. These
+            // may not exist, e.g., if the file has been stripped. In that case, we look for the
+            // special __start and __stop symbols themselves.
+            if let Some(section) = object.section_headers.iter().find_map(|header| {
+                if let Some(name) = object.shdr_strtab.get_at(header.sh_name) {
+                    if name == "set_dtrace_probes" {
+                        Some(header)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }) {
+                let start = section.sh_offset as usize;
+                let end = start + (section.sh_size as usize);
+                Some(&data[start..end])
+            } else {
+                // Failed to look up the section directly, iterate over the symbols.
+                let mut bounds = object.syms.iter().filter(|symbol| {
+                    matches!(
+                        object.strtab.get_at(symbol.st_name),
+                        Some("__start_set_dtrace_probes") | Some("__stop_set_dtrace_probes")
+                    )
+                });
+
+                if let (Some(start), Some(stop)) = (bounds.next(), bounds.next()) {
+                    let (start, stop) = (start.st_value as usize, stop.st_value as usize);
+                    Some(&data[start..stop])
+                } else {
+                    None
+                }
+            }
+        }
+        Object::Mach(goblin::mach::Mach::Binary(object)) => {
+            // Try to find our special `__dtrace_probes` section from the section headers.
+            for (section, sdata) in object.segments.sections().flatten().flatten() {
+                if section.sectname.starts_with(b"__dtrace_probes") {
+                    return Some(sdata);
+                }
+            }
+
+            // Failed to look up the section directly, iterate over the symbols
+            if let Some(syms) = object.symbols {
+                let mut bounds = syms.iter().filter_map(|symbol| {
+                    if let Ok((name, nlist)) = symbol {
+                        if name.contains("__dtrace_probes") {
+                            Some(nlist.n_value as usize)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                });
+                if let (Some(start), Some(stop)) = (bounds.next(), bounds.next()) {
+                    Some(&data[start..stop])
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
 }

--- a/probe-test-build/build.rs
+++ b/probe-test-build/build.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use usdt::Builder;
-use version_check;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/tests/argument-types/src/main.rs
+++ b/tests/argument-types/src/main.rs
@@ -103,7 +103,7 @@ fn main() {
     refs::array!(|| &arr);
 
     // Tuples may be passed in by value.
-    refs::tuple!(|| ((0, &x[..])));
+    refs::tuple!(|| (0, &x[..]));
 
     // Serializable types may be passed by value or reference, to a probe expecting either a value
     // or a reference. Note, however, that the normal lifetime rules apply: you can't return a
@@ -114,9 +114,9 @@ fn main() {
     // refs::serializable_as_reference!(|| &crate::Arg::default());
     // ```
     let arg = crate::Arg::default();
-    refs::serializable_as_value!(|| crate::Arg::default());
+    refs::serializable_as_value!(crate::Arg::default);
     refs::serializable_as_value!(|| &arg);
-    refs::serializable_as_reference!(|| crate::Arg::default());
+    refs::serializable_as_reference!(crate::Arg::default);
     refs::serializable_as_reference!(|| &arg);
 
     // It's also possible to capture and return local variables by value in the probe argument

--- a/tests/does-it-work/build.rs
+++ b/tests/does-it-work/build.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use usdt::Builder;
-use version_check;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/tests/empty/build.rs
+++ b/tests/empty/build.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use usdt::Builder;
-use version_check;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/tests/fake-lib/build.rs
+++ b/tests/fake-lib/build.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use usdt::Builder;
-use version_check;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/tests/rename-builder/build.rs
+++ b/tests/rename-builder/build.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use usdt::Builder;
-use version_check;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/tests/zero-arg-probe/build.rs
+++ b/tests/zero-arg-probe/build.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use usdt::Builder;
-use version_check;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 proc-macro = true
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.12" }
+dtrace-parser = { path = "../dtrace-parser" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.3.2", default-features = false }
+usdt-impl = { path = "../usdt-impl", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt-attr-macro/src/lib.rs
+++ b/usdt-attr-macro/src/lib.rs
@@ -215,10 +215,10 @@ fn parse_probe_argument(
                 }
                 Ok((None, data_type_from_path(&path.path, true)))
             } else {
-                return Err(syn::Error::new(
+                Err(syn::Error::new(
                     item.span(),
                     "Only pointers to path types are supported",
-                ));
+                ))
             }
         }
         syn::Type::Reference(ref reference) => {

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 byteorder = "1"
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.12" }
+dtrace-parser = { path = "../dtrace-parser" }
 libc = "0.2"
 proc-macro2 = "1"
 quote = "1"
@@ -24,10 +24,10 @@ thread-id = "4"
 version_check = "0.9.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }
+dof = { path = "../dof", optional = true, default-features = false }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-dof = { path = "../dof", version = "0.1.5", default-features = false }
+dof = { path = "../dof", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 [dependencies]
 byteorder = "1"
 dtrace-parser = { path = "../dtrace-parser", version = "0.1.12" }
-goblin = { version = "0.4", features = [ "elf32", "elf64" ], optional = true }
 libc = "0.2"
 proc-macro2 = "1"
 quote = "1"
@@ -31,6 +30,10 @@ dof = { path = "../dof", version = "0.1.5", optional = true, default-features = 
 dof = { path = "../dof", version = "0.1.5", default-features = false }
 
 [features]
-asm = []
-des = ["goblin", "dof", "dof/des"]
 default = ["asm"]
+asm = []
+# The `des` feature enables `dof` and company to be able to deserialize special
+# sections emitted in the binary which describe the probes.  Except on
+# platforms with linker integration for USDT probes (currently only MacOS),
+# that data is required in order to register the probes with the kernel.
+des = ["dof", "dof/des"]

--- a/usdt-impl/build.rs
+++ b/usdt-impl/build.rs
@@ -1,1 +1,90 @@
-../common-build.rs
+// Copyright 2022 Oxide Computer Company
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::env;
+
+use version_check;
+
+#[derive(Copy, Clone)]
+enum Backend {
+    // Standard (read: illumos) probe registration
+    Standard,
+    // MacOS linker-aware probe registration
+    Linker,
+    // Provide probe macros, but probes are no-ops (dtrace-less OSes)
+    NoOp,
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // `asm` feature was stabilized in 1.59
+    let have_stable_asm = version_check::is_min_version("1.59").unwrap_or(false);
+    // XXX: `asm_sym` feature is not yet stable
+    let have_stable_asm_sym = false;
+
+    // Are we being built with a compiler which allows feature flags (nightly)
+    let is_nightly = version_check::is_feature_flaggable().unwrap_or(false);
+
+    let feat_asm = env::var_os("CARGO_FEATURE_ASM").is_some();
+    let feat_strict_asm = env::var_os("CARGO_FEATURE_STRICT_ASM").is_some();
+
+    let backend = match env::var("CARGO_CFG_TARGET_OS").ok().as_deref() {
+        Some("macos") if feat_asm => {
+            if have_stable_asm && have_stable_asm_sym {
+                Backend::Linker
+            } else if feat_strict_asm || is_nightly {
+                if !have_stable_asm {
+                    println!("cargo:rustc-cfg=usdt_need_feat_asm");
+                }
+                if !have_stable_asm_sym {
+                    println!("cargo:rustc-cfg=usdt_need_feat_asm_sym");
+                }
+                Backend::Linker
+            } else {
+                Backend::NoOp
+            }
+        }
+        Some("illumos") | Some("solaris") if feat_asm => {
+            if have_stable_asm {
+                Backend::Standard
+            } else if feat_strict_asm || is_nightly {
+                println!("cargo:rustc-cfg=usdt_need_feat_asm");
+                Backend::Standard
+            } else {
+                Backend::NoOp
+            }
+        }
+        _ => Backend::NoOp,
+    };
+
+    // Since visibility of the `asm!()` macro differs between the nightly feature and the
+    // stabilized version, the consumer requires information about its availability
+    if have_stable_asm {
+        println!("cargo:rustc-cfg=usdt_stable_asm");
+    }
+
+    match backend {
+        Backend::NoOp => {
+            println!("cargo:rustc-cfg=usdt_backend_noop");
+        }
+        Backend::Linker => {
+            println!("cargo:rustc-cfg=usdt_backend_linker");
+        }
+        Backend::Standard => {
+            println!("cargo:rustc-cfg=usdt_backend_standard");
+        }
+    }
+}

--- a/usdt-impl/src/common.rs
+++ b/usdt-impl/src/common.rs
@@ -92,7 +92,7 @@ pub fn generate_type_check(
         })
         .collect::<Vec<_>>();
 
-    let preamble = unpack_argument_lambda(&types, /* clone = */ true);
+    let preamble = unpack_argument_lambda(types, /* clone = */ true);
 
     let type_check_function =
         format_ident!("__usdt_private_{}_{}_type_check", provider_name, probe_name);

--- a/usdt-impl/src/empty.rs
+++ b/usdt-impl/src/empty.rs
@@ -61,7 +61,7 @@ fn compile_provider(provider: &Provider, config: &crate::CompileProvidersConfig)
     let probe_impls = provider
         .probes
         .iter()
-        .map(|probe| compile_probe(&provider, probe, config))
+        .map(|probe| compile_probe(provider, probe, config))
         .collect::<Vec<_>>();
     let module = config.module_ident();
     quote! {

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -49,7 +49,7 @@ pub fn process_section(mut data: &[u8]) -> Result<Section, crate::Error> {
         let mut len_bytes = data;
         let len = len_bytes.read_u32::<NativeEndian>()? as usize;
         let (rec, rest) = data.split_at(len);
-        process_probe_record(&mut providers, &rec)?;
+        process_probe_record(&mut providers, rec)?;
         data = rest;
     }
 
@@ -174,7 +174,7 @@ fn process_probe_record(
     let probe = provider.probes.entry(probename.clone()).or_insert(Probe {
         name: probename,
         function: funcname,
-        address: address,
+        address,
         offsets: vec![],
         enabled_offsets: vec![],
         arguments: vec![],

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -9,12 +9,12 @@ description = "Procedural macro for generating Rust macros for USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.12" }
+dtrace-parser = { path = "../dtrace-parser" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.3.2", default-features = false }
+usdt-impl = { path = "../usdt-impl", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt-macro/src/lib.rs
+++ b/usdt-macro/src/lib.rs
@@ -122,8 +122,7 @@ pub fn dtrace_provider(item: proc_macro::TokenStream) -> proc_macro::TokenStream
         Err(e) => {
             let message = format!(
                 "Error building provider definition in \"{}\"\n\n{}",
-                filename,
-                e.to_string()
+                filename, e
             );
             let out = quote! {
                 compile_error!(#message);

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -9,11 +9,11 @@ description = "Dust your Rust with USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.12", optional = true }
+dtrace-parser = { path = "../dtrace-parser", optional = true }
 serde = "1"
-usdt-impl = { path = "../usdt-impl", version = "0.3.2", default-features = false }
-usdt-macro = { path = "../usdt-macro", version = "0.3.2", default-features = false }
-usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.3.2", default-features = false }
+usdt-impl = { path = "../usdt-impl", default-features = false }
+usdt-macro = { path = "../usdt-macro", default-features = false }
+usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false }
 
 [features]
 default = ["asm"]

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -15,13 +15,6 @@ usdt-impl = { path = "../usdt-impl", version = "0.3.2", default-features = false
 usdt-macro = { path = "../usdt-macro", version = "0.3.2", default-features = false }
 usdt-attr-macro = { path = "../usdt-attr-macro", version = "0.3.2", default-features = false }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-dof = { path = "../dof", version = "0.1.5", optional = true, default-features = false }
-
-[target.'cfg(not(target_os = "macos"))'.dependencies]
-dof = { path = "../dof", version = "0.1.5", default-features = false }
-
 [features]
 default = ["asm"]
 asm = ["usdt-impl/asm", "usdt-macro/asm", "usdt-attr-macro/asm", "dtrace-parser"]
-des = ["usdt-impl/des", "dof/des"]

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -368,8 +368,6 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 pub use usdt_attr_macro::provider;
-#[cfg(any(feature = "des"))]
-pub use usdt_impl::record;
 #[doc(hidden)]
 pub use usdt_impl::to_json;
 pub use usdt_impl::{Error, UniqueId};


### PR DESCRIPTION
This retools `asm` and `asm_sym` feature inside the usdt implementation to make fallback more smooth when built with a compiler which does not support the necessary features.  Consumers wanting the old behavior, where the crate will fail to build if they do not have a supported compiler and necessary enabled features, is preserved with the `strict-asm` feature.  Without `strict-asm` enabled, the usdt-impl `build.rs` will quietly fall back to the no-op probe implementation if compiler functionality is not met.