### PR TITLE
Add both path and version dependencies

### DIFF
--- a/dtrace-parser/Cargo.toml
+++ b/dtrace-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtrace-parser"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-attr-macro"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Benjamin Naecker <ben@oxide.computer>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,12 +11,12 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 proc-macro = true
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.14" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "0.3.4" }
 
 [features]
 default = ["asm"]

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -11,12 +11,12 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 proc-macro = true
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.14" }
+dtrace-parser = { path = "../dtrace-parser", version = "= 0.1.14" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false, version = "0.3.4" }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "= 0.3.4" }
 
 [features]
 default = ["asm"]

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 byteorder = "1"
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.14" }
+dtrace-parser = { path = "../dtrace-parser", version = "= 0.1.14" }
 libc = "0.2"
 proc-macro2 = "1"
 quote = "1"
@@ -24,10 +24,10 @@ thread-id = "4"
 version_check = "0.9.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dof = { path = "../dof", optional = true, default-features = false, version = "0.1.5" }
+dof = { path = "../dof", optional = true, default-features = false, version = "= 0.1.5" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-dof = { path = "../dof", default-features = false, version = "0.1.5" }
+dof = { path = "../dof", default-features = false, version = "= 0.1.5" }
 
 [features]
 default = ["asm"]

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -10,7 +10,7 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 byteorder = "1"
-dtrace-parser = { path = "../dtrace-parser" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.14" }
 libc = "0.2"
 proc-macro2 = "1"
 quote = "1"
@@ -24,10 +24,10 @@ thread-id = "4"
 version_check = "0.9.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dof = { path = "../dof", optional = true, default-features = false }
+dof = { path = "../dof", optional = true, default-features = false, version = "0.1.5" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-dof = { path = "../dof", default-features = false }
+dof = { path = "../dof", default-features = false, version = "0.1.5" }
 
 [features]
 default = ["asm"]

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -9,12 +9,12 @@ description = "Procedural macro for generating Rust macros for USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "0.1.14" }
+dtrace-parser = { path = "../dtrace-parser", version = "= 0.1.14" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false, version = "0.3.4" }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "= 0.3.4" }
 
 [features]
 default = ["asm"]

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-macro"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -9,12 +9,12 @@ description = "Procedural macro for generating Rust macros for USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser" }
+dtrace-parser = { path = "../dtrace-parser", version = "0.1.14" }
 proc-macro2 = "1"
 serde_tokenstream = "0.1"
 syn = { version = "1", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "0.3.4" }
 
 [features]
 default = ["asm"]

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -8,12 +8,19 @@ license = "Apache-2.0"
 description = "Dust your Rust with USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
+# NOTE: The use of path and version dependencies is deliberate and load-bearing.
+#
+# When building from source, this will select the version in the workspace, by
+# path. When publishing the specific version will be used. Combined with the
+# exact version requirements, this prevents issues like oxidecomputer/usdt#69,
+# where the public-facing `usdt` crate may pick up different versions of the
+# internal implementation crates.
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", optional = true, version = "0.1.14" }
+dtrace-parser = { path = "../dtrace-parser", optional = true, version = "= 0.1.14" }
 serde = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false, version = "0.3.4" }
-usdt-macro = { path = "../usdt-macro", default-features = false, version = "0.3.4" }
-usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false, version = "0.3.4" }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "= 0.3.4" }
+usdt-macro = { path = "../usdt-macro", default-features = false, version = "= 0.3.4" }
+usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false, version = "= 0.3.4" }
 
 [features]
 default = ["asm"]

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
            "Adam H. Leventhal <ahl@oxidecomputer.com>"]
 edition = "2018"
@@ -9,11 +9,11 @@ description = "Dust your Rust with USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", optional = true }
+dtrace-parser = { path = "../dtrace-parser", optional = true, version = "0.1.14" }
 serde = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false }
-usdt-macro = { path = "../usdt-macro", default-features = false }
-usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "0.3.4" }
+usdt-macro = { path = "../usdt-macro", default-features = false, version = "0.3.4" }
+usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false, version = "0.3.4" }
 
 [features]
 default = ["asm"]


### PR DESCRIPTION
A previous commit removed the version specification for the path dependencies in the repository. This all works fine, until the crates are published. Crates on crates.io may not have path dependencies, but there is no version to use.

The accepted solution appears to be to specify _both_ path and version dependencies. The former is used when building from source, the latter when publishing.