### PR TITLE
Reworks probe record version manipulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ version = "0.1.0"
 dependencies = [
  "dof",
  "goblin",
+ "memmap",
  "structopt",
  "usdt-impl",
 ]
@@ -354,6 +355,16 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "modules"

--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -9,5 +9,6 @@ license = "Apache-2.0"
 [dependencies]
 dof = { path = "../dof", features = [ "des" ] }
 goblin = { version = "0.6", features = [ "elf32", "elf64" ] }
+memmap = "0.7"
 structopt = "0.3.21"
 usdt-impl = { path = "../usdt-impl", features = ["des"] }

--- a/dusty/src/main.rs
+++ b/dusty/src/main.rs
@@ -14,11 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-
 use dof::Section;
 use goblin::Object;
+use memmap::Mmap;
+use memmap::MmapOptions;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::path::Path;
+use std::path::PathBuf;
 use structopt::StructOpt;
 use usdt_impl::Error as UsdtError;
 
@@ -66,15 +69,23 @@ fn main() {
 }
 
 // Extract probe records from the given file, if possible.
-pub(crate) fn probe_records<P: AsRef<Path>>(file: P) -> Result<Section, UsdtError> {
-    let data = fs::read(file)?;
-    let section = locate_probe_section(&data).ok_or(UsdtError::InvalidFile)?;
+pub(crate) fn probe_records<P: AsRef<Path>>(path: P) -> Result<Section, UsdtError> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(false)
+        .open(path)?;
+    let (offset, len) = locate_probe_section(&file).ok_or(UsdtError::InvalidFile)?;
 
-    usdt_impl::record::process_section(section)
+    // Remap only the probe section itself as mutable.
+    let mut map = unsafe { MmapOptions::new().offset(offset).len(len).map_mut(&file)? };
+    usdt_impl::record::process_section(&mut map, /* register = */ false)
 }
 
-fn locate_probe_section(data: &[u8]) -> Option<&[u8]> {
-    match Object::parse(data).ok()? {
+// Return the offset and size of the file's probe record section, if it exists.
+fn locate_probe_section(file: &File) -> Option<(u64, usize)> {
+    let map = unsafe { Mmap::map(file) }.ok()?;
+    match Object::parse(&map).ok()? {
         Object::Elf(object) => {
             // Try to find our special `set_dtrace_probes` section from the section headers. These
             // may not exist, e.g., if the file has been stripped. In that case, we look for the
@@ -90,9 +101,7 @@ fn locate_probe_section(data: &[u8]) -> Option<&[u8]> {
                     None
                 }
             }) {
-                let start = section.sh_offset as usize;
-                let end = start + (section.sh_size as usize);
-                Some(&data[start..end])
+                Some((section.sh_offset, section.sh_size as usize))
             } else {
                 // Failed to look up the section directly, iterate over the symbols.
                 let mut bounds = object.syms.iter().filter(|symbol| {
@@ -103,8 +112,7 @@ fn locate_probe_section(data: &[u8]) -> Option<&[u8]> {
                 });
 
                 if let (Some(start), Some(stop)) = (bounds.next(), bounds.next()) {
-                    let (start, stop) = (start.st_value as usize, stop.st_value as usize);
-                    Some(&data[start..stop])
+                    Some((start.st_value, (stop.st_value - start.st_value) as usize))
                 } else {
                     None
                 }
@@ -112,18 +120,18 @@ fn locate_probe_section(data: &[u8]) -> Option<&[u8]> {
         }
         Object::Mach(goblin::mach::Mach::Binary(object)) => {
             // Try to find our special `__dtrace_probes` section from the section headers.
-            for (section, sdata) in object.segments.sections().flatten().flatten() {
+            for (section, _) in object.segments.sections().flatten().flatten() {
                 if section.sectname.starts_with(b"__dtrace_probes") {
-                    return Some(sdata);
+                    return Some((section.offset as u64, section.size as usize));
                 }
             }
 
-            // Failed to look up the section directly, iterate over the symbols
+            // Failed to look up the section directly, iterate over the symbols.
             if let Some(syms) = object.symbols {
                 let mut bounds = syms.iter().filter_map(|symbol| {
                     if let Ok((name, nlist)) = symbol {
                         if name.contains("__dtrace_probes") {
-                            Some(nlist.n_value as usize)
+                            Some(nlist.n_value)
                         } else {
                             None
                         }
@@ -132,7 +140,7 @@ fn locate_probe_section(data: &[u8]) -> Option<&[u8]> {
                     }
                 });
                 if let (Some(start), Some(stop)) = (bounds.next(), bounds.next()) {
-                    Some(&data[start..stop])
+                    Some((start, (stop - start) as usize))
                 } else {
                     None
                 }

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -138,9 +138,9 @@ fn extract_probe_records_from_section() -> Result<Section, crate::Error> {
     let data = unsafe {
         let start = (&dtrace_probes_start as *const usize) as usize;
         let stop = (&dtrace_probes_stop as *const usize) as usize;
-        std::slice::from_raw_parts(start as *const u8, stop - start)
+        std::slice::from_raw_parts_mut(start as *mut u8, stop - start)
     };
-    process_section(data)
+    process_section(data, /* register = */ true)
 }
 
 pub fn register_probes() -> Result<(), crate::Error> {


### PR DESCRIPTION
- The `dusty` binary now `mmap`s the target file, rather than reading the whole thing in. This trades a bit of speed in the form of page faults, for laziness, and only reads the required portions of the file.
- Reworks how we read and potentially update the probe record version stored in the target file. First, adds an argument to the `process_section` function controlling whether we want to bother updating the version. `dusty` does not set this, whereas the code that registers the probes does. Second, makes the bytes in which the probe records are stored mutable everywhere, which properly communicates the intent that these may be updated. Lastly, we avoid further inline assembly and some portability issues by using an atomic rather than a `lock xchg` instruction. That currently works by transmuting the byte storing the probe record version, but may work with no unsafe code when the `AtomicU8::from_mut` method is stabilized. In either case, the code should be sound at this point, since writing to that data is now done through an exclusive reference.