### PR TITLE
Add JSON support to dusty

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,7 @@ jobs:
           --verbose
           --workspace
           --exclude compile-errors
+          --exclude dusty
 
   recent-nightly-no-support:
     name: Run tests on a recent nightly
@@ -129,6 +130,7 @@ jobs:
           --exclude does-it-work
           --exclude test-json
           --exclude test-unique-id
+          --exclude dusty
 
   old-nightly:
     name: Run tests on an older nightly
@@ -150,6 +152,7 @@ jobs:
           --verbose
           --workspace
           --exclude compile-errors
+          --exclude dusty 
 
   old-nightly-no-support:
     name: Run tests on an older nightly
@@ -174,3 +177,4 @@ jobs:
           --exclude does-it-work
           --exclude test-json
           --exclude test-unique-id
+          --exclude dusty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,8 @@ version = "0.1.5"
 dependencies = [
  "goblin",
  "pretty-hex",
+ "serde",
+ "serde_json",
  "thiserror",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,51 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
 ]
 
 [[package]]
@@ -18,17 +57,6 @@ dependencies = [
  "serde",
  "usdt",
  "version_check",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -75,18 +103,49 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.35",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "compile-errors"
@@ -163,10 +222,10 @@ dependencies = [
 name = "dusty"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "dof",
  "goblin",
  "memmap",
- "structopt",
  "usdt-impl",
 ]
 
@@ -318,33 +377,15 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -480,30 +521,6 @@ name = "probe-test-macro"
 version = "0.1.0"
 dependencies = [
  "usdt",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
  "version_check",
 ]
 
@@ -684,33 +701,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subprocess"
@@ -771,15 +764,6 @@ dependencies = [
  "subprocess",
  "usdt",
  "version_check",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -845,18 +829,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "usdt"
@@ -927,10 +899,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
+name = "utf8parse"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"
@@ -968,6 +940,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zero-arg-probe"

--- a/dof/Cargo.toml
+++ b/dof/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "dof"
 version = "0.1.5"
-authors = ["Benjamin Naecker <ben@oxidecomputer.com>",
-           "Adam H. Leventhal <ahl@oxidecomputer.com>"]
+authors = [
+  "Benjamin Naecker <ben@oxidecomputer.com>",
+  "Adam H. Leventhal <ahl@oxidecomputer.com>",
+]
 edition = "2018"
 license = "Apache-2.0"
 description = "Tools to read and write the DTrace Object Format (DOF)"
@@ -13,6 +15,8 @@ goblin = { version = "0.6", optional = true, features = ["elf64", "mach64"] }
 pretty-hex = { version = "0.3", optional = true }
 thiserror = "1"
 zerocopy = "0.6"
+serde = "1"
+serde_json = "1"
 
 [features]
 des = ["pretty-hex", "goblin"]

--- a/dof/src/dof.rs
+++ b/dof/src/dof.rs
@@ -25,6 +25,7 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 
+use serde::Serialize;
 use thiserror::Error;
 
 // Magic bytes for a DOF section
@@ -56,7 +57,7 @@ pub enum Error {
 }
 
 /// Represents the DTrace data model, e.g. the pointer width of the platform
-#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 #[repr(u8)]
 pub enum DataModel {
     None = 0,
@@ -87,7 +88,7 @@ impl TryFrom<u8> for DataModel {
 }
 
 /// Represents the endianness of the platform
-#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 #[repr(u8)]
 pub enum DataEncoding {
     None = 0,
@@ -118,7 +119,7 @@ impl TryFrom<u8> for DataEncoding {
 }
 
 /// Static identifying information about a DOF section (such as version numbers)
-#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[derive(Debug, Clone, Copy, Serialize)]
 pub struct Ident {
     pub magic: [u8; 4],
     pub model: DataModel,
@@ -174,7 +175,7 @@ impl Ident {
 }
 
 /// Representation of a DOF section of an object file
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Section {
     /// The identifying bytes of this section
     pub ident: Ident,
@@ -196,7 +197,7 @@ impl Section {
 
     /// Serialize a section into a JSON representation of the DOF object file section.
     pub fn to_json(&self) -> String {
-        serde_json::to_string(self).unwrap()
+        serde_json::to_string_pretty(self).unwrap()
     }
 }
 
@@ -218,7 +219,7 @@ impl Default for Section {
 }
 
 /// Information about a single DTrace probe
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Probe {
     /// Name of this probe
     pub name: String,
@@ -235,7 +236,7 @@ pub struct Probe {
 }
 
 /// Information about a single provider
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Provider {
     /// Name of the provider
     pub name: String,

--- a/dof/src/dof.rs
+++ b/dof/src/dof.rs
@@ -196,7 +196,7 @@ impl Section {
 
     /// Serialize a section into a JSON representation of the DOF object file section.
     pub fn to_json(&self) -> String {
-        serde_json::to_string_pretty(self).unwrap()
+        serde_json::to_string(self).unwrap()
     }
 }
 

--- a/dof/src/dof.rs
+++ b/dof/src/dof.rs
@@ -56,7 +56,7 @@ pub enum Error {
 }
 
 /// Represents the DTrace data model, e.g. the pointer width of the platform
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 #[repr(u8)]
 pub enum DataModel {
     None = 0,
@@ -87,7 +87,7 @@ impl TryFrom<u8> for DataModel {
 }
 
 /// Represents the endianness of the platform
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 #[repr(u8)]
 pub enum DataEncoding {
     None = 0,
@@ -118,7 +118,7 @@ impl TryFrom<u8> for DataEncoding {
 }
 
 /// Static identifying information about a DOF section (such as version numbers)
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct Ident {
     pub magic: [u8; 4],
     pub model: DataModel,
@@ -174,7 +174,7 @@ impl Ident {
 }
 
 /// Representation of a DOF section of an object file
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Section {
     /// The identifying bytes of this section
     pub ident: Ident,
@@ -192,6 +192,11 @@ impl Section {
     /// Serialize a section into DOF object file section.
     pub fn as_bytes(&self) -> Vec<u8> {
         crate::ser::serialize_section(self)
+    }
+
+    /// Serialize a section into a JSON representation of the DOF object file section.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap()
     }
 }
 
@@ -213,7 +218,7 @@ impl Default for Section {
 }
 
 /// Information about a single DTrace probe
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Probe {
     /// Name of this probe
     pub name: String,
@@ -230,7 +235,7 @@ pub struct Probe {
 }
 
 /// Information about a single provider
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Provider {
     /// Name of the provider
     pub name: String,

--- a/dof/src/fmt.rs
+++ b/dof/src/fmt.rs
@@ -94,13 +94,13 @@ fn fmt_dof_sec_type<T: Debug + FromBytes + Copy>(data: &[u8]) -> String {
 
 #[derive(Clone, Copy)]
 pub enum FormatMode {
-    // Output is formatted as the Rust types used to represent DOF data throughout the `usdt` crate.
+    // Emit Rust types used by the usdt crate
     Pretty,
-    // The same out as `Pretty`, but formatted as JSON.
+    // Emit Rust types as json for parsing
     Json,
-    /// Underlying DOF C structs are formatted
+    /// Emit underlying DOF C types
     Raw {
-        /// If true, the DOF section data is included, along with the secion headers.
+        /// If true, the DOF section data is included, along with the section headers.
         /// If false, only the section headers are printed.
         include_sections: bool,
     },

--- a/dof/src/fmt.rs
+++ b/dof/src/fmt.rs
@@ -92,39 +92,62 @@ fn fmt_dof_sec_type<T: Debug + FromBytes + Copy>(data: &[u8]) -> String {
         .join("\n")
 }
 
+#[derive(Clone, Copy)]
+pub enum FormatMode {
+    // Output is formatted as the Rust types used to represent DOF data throughout the `usdt` crate.
+    Pretty,
+    // The same out as `Pretty`, but formatted as JSON.
+    Json,
+    /// Underlying DOF C structs are formatted
+    Raw {
+        /// If true, the DOF section data is included, along with the secion headers.
+        /// If false, only the section headers are printed.
+        include_sections: bool,
+    },
+}
+
 /// Format all DOF data in an object file into a pretty-printable string.
 ///
-/// If `raw` is true, then the raw, underlying DOF C structs are formatted. If false, the data is
-/// formatted as the Rust types used to represent DOF data throughout the `usdt` crate.
-///
-/// If `include_sections` is true, the DOF binary section data is included, along with the section
-/// headers. If false, only the section headers are printed.
+/// Uses the `FormatMode` to determine how the data is formatted.
 ///
 /// If the file is not of the correct format, or has invalid DOF data, an `Err` is returned. If the
 /// file has no DOF data, `None` is returned.
 pub fn fmt_dof<P: AsRef<Path>>(
     file: P,
-    raw: bool,
-    include_sections: bool,
+    format: FormatMode,
 ) -> Result<Option<String>, crate::Error> {
     let mut out = String::new();
-    if raw {
-        let sections = crate::collect_dof_sections(&file)?.into_iter();
-        for section in sections {
-            let RawSections { header, sections } = crate::des::deserialize_raw_sections(&section)?;
-            out.push_str(&format!("{:#?}\n", header));
-            for (index, (section_header, data)) in sections.into_iter().enumerate() {
-                out.push_str(&format!("{}\n", fmt_dof_sec(&section_header, index)));
-                if include_sections {
-                    out.push_str(&format!("{}\n", fmt_dof_sec_data(&section_header, &data)));
+    match format {
+        FormatMode::Raw { include_sections } => {
+            let sections = crate::collect_dof_sections(&file)?.into_iter();
+            for section in sections {
+                let RawSections { header, sections } =
+                    crate::des::deserialize_raw_sections(&section)?;
+                out.push_str(&format!("{:#?}\n", header));
+                for (index, (section_header, data)) in sections.into_iter().enumerate() {
+                    out.push_str(&format!("{}\n", fmt_dof_sec(&section_header, index)));
+                    if include_sections {
+                        out.push_str(&format!("{}\n", fmt_dof_sec_data(&section_header, &data)));
+                    }
                 }
             }
         }
-    } else {
-        for section in crate::extract_dof_sections(&file)?.iter() {
-            out.push_str(&format!("{:#?}\n", section));
+        FormatMode::Json => {
+            let dof_sections = crate::extract_dof_sections(&file)?;
+            let sections = dof_sections.iter();
+            for section in sections {
+                out.push_str(section.to_json().as_str());
+            }
+        }
+        FormatMode::Pretty => {
+            let dof_sections = crate::extract_dof_sections(&file)?;
+            let sections = dof_sections.iter();
+            for section in sections {
+                out.push_str(&format!("{:#?}\n", section));
+            }
         }
     }
+
     if out.is_empty() {
         Ok(None)
     } else {

--- a/dof/src/fmt.rs
+++ b/dof/src/fmt.rs
@@ -92,6 +92,7 @@ fn fmt_dof_sec_type<T: Debug + FromBytes + Copy>(data: &[u8]) -> String {
         .join("\n")
 }
 
+/// Controls how DOF data is formatted
 #[derive(Clone, Copy)]
 pub enum FormatMode {
     // Emit Rust types used by the usdt crate

--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -7,8 +7,8 @@ description = "Tool to inspect USDT probe records in object files"
 license = "Apache-2.0"
 
 [dependencies]
+clap = { version = "4.4.11", features = ["derive"] }
 dof = { path = "../dof", features = [ "des" ] }
 goblin = { version = "0.6", features = [ "elf32", "elf64" ] }
 memmap = "0.7"
-structopt = "0.3.21"
 usdt-impl = { path = "../usdt-impl", features = ["des"] }

--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -5,10 +5,11 @@ authors = ["Benjamin Naecker <ben@oxidecomputer.com>"]
 edition = "2018"
 description = "Tool to inspect USDT probe records in object files"
 license = "Apache-2.0"
+rust-version = "1.70.0"
 
 [dependencies]
 clap = { version = "4.4.11", features = ["derive"] }
-dof = { path = "../dof", features = [ "des" ] }
-goblin = { version = "0.6", features = [ "elf32", "elf64" ] }
+dof = { path = "../dof", features = ["des"] }
+goblin = { version = "0.6", features = ["elf32", "elf64"] }
 memmap = "0.7"
 usdt-impl = { path = "../usdt-impl", features = ["des"] }

--- a/dusty/src/main.rs
+++ b/dusty/src/main.rs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use clap::Parser;
 use dof::Section;
 use goblin::Object;
 use memmap::Mmap;
@@ -22,31 +23,29 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::path::Path;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use usdt_impl::Error as UsdtError;
 
 /// Inspect data related to USDT probes in object files.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Cmd {
     /// The object file to inspect
-    #[structopt(parse(from_os_str))]
     file: PathBuf,
 
     /// Operate more verbosely, printing all available information
-    #[structopt(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 
     /// Print raw binary data along with summaries or headers
-    #[structopt(short, long)]
+    #[arg(short, long, conflicts_with = "json")]
     raw: bool,
 
-    /// Format output as JSON. Not compatible with `--raw`.
-    #[structopt(long)]
+    /// Format output as JSON
+    #[arg(short, long)]
     json: bool,
 }
 
 fn main() {
-    let cmd = Cmd::from_args();
+    let cmd = Cmd::parse();
     let format_mode = if cmd.raw {
         dof::fmt::FormatMode::Raw {
             include_sections: cmd.verbose,


### PR DESCRIPTION
Having just recently learned out useful dtrace is, I'm on a bit of a mission to make what we can do with it more visible. The first part in that story is making it easier to programmatically munge the output of dusty, thus a new JSON mode.

I updated `dof` to include serde serialization of the `Section` struct and its children. I did make a breaking change to `fmt_dof` to have it take in an enum struct called `FormatMode` instead of the flags it was previously taking. The flags were somewhat misrepresentative because `include_sections` was only relevant when in raw mode. Overall I just felt this a better mechanism of invocation, especially when considering adding a new flag. 