### PR TITLE
Fix race in JSON tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,12 +142,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-01
+          toolchain: nightly-2022-07-01
           override: true
           profile: minimal
       - run: >
           RUST_BACKTRACE=1
-          cargo +nightly-2022-06-01 test
+          cargo +nightly-2022-07-01 test
           --release
           --verbose
           --workspace
@@ -164,12 +164,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-06-01
+          toolchain: nightly-2022-07-01
           override: true
           profile: minimal
       - run: >
           RUST_BACKTRACE=1
-          cargo +nightly-2022-06-01 test
+          cargo +nightly-2022-07-01 test
           --release
           --verbose
           --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,7 +52,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -47,7 +62,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -66,6 +81,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "basic-toml"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,6 +103,12 @@ checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
@@ -88,6 +124,21 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -352,6 +403,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,9 +445,19 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -409,6 +482,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "modules"
 version = "0.0.0"
 dependencies = [
@@ -418,10 +511,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "pest"
@@ -536,6 +671,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rename"
 version = "0.0.0"
 dependencies = [
@@ -580,6 +724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +743,12 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -675,12 +831,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -736,6 +917,7 @@ version = "0.0.0"
 dependencies = [
  "serde",
  "serde_json",
+ "tokio",
  "usdt",
  "usdt-tests-common",
  "version_check",
@@ -778,6 +960,36 @@ checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "tokio"
+version = "1.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -897,6 +1109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,11 +1147,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -942,14 +1184,20 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -959,9 +1207,21 @@ checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -971,9 +1231,21 @@ checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -983,9 +1255,21 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/tests/does-it-work/src/main.rs
+++ b/tests/does-it-work/src/main.rs
@@ -2,7 +2,7 @@
 //! registers a single probe with arguments, and then verifies that this probe is visible to the
 //! `dtrace(1)` command-line tool.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,7 +48,8 @@ mod tests {
     fn test_does_it_work() {
         let (send, recv) = channel();
         let thr = thread::spawn(move || run_test(recv));
-        let dtrace = root_command("dtrace")
+        let dtrace = std::process::Command::new(root_command())
+            .arg("dtrace")
             .arg("-l")
             .arg("-v")
             .arg("-n")

--- a/tests/test-json/Cargo.toml
+++ b/tests/test-json/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = "*"
 
 [build-dependencies]
 version_check = "0.9.4"
+
+[dev-dependencies]
+tokio = { version = "1.35.1", features = [ "full" ] }

--- a/tests/test-json/src/main.rs
+++ b/tests/test-json/src/main.rs
@@ -135,8 +135,7 @@ mod tests {
         let now = Instant::now();
         wait_for_begin_sentinel(&mut dtrace, &now).await;
 
-        // We should now see the probe having fired exactly once. Grab the output data, kill the
-        // DTrace process, and then parse the output as JSON.
+        // Instruct the task firing probes to continue.
         tx.send(()).await.unwrap();
 
         // Wait for the process to finish, up to a pretty generous limit.

--- a/tests/test-json/src/main.rs
+++ b/tests/test-json/src/main.rs
@@ -1,6 +1,6 @@
 //! Integration test verifying JSON output, including when serialization fails.
 
-// Copyright 2022 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,102 +67,139 @@ mod tests {
     use super::*;
     use serde_json::Value;
     use std::process::Stdio;
-    use std::sync::mpsc::Sender;
-    use std::sync::mpsc::{channel, Receiver};
-    use std::thread::sleep;
     use std::time::Duration;
-    use std::time::Instant;
+    use tokio::io::AsyncReadExt;
+    use tokio::process::Child;
+    use tokio::process::Command;
+    use tokio::sync::mpsc::channel;
+    use tokio::sync::mpsc::Receiver;
+    use tokio::sync::mpsc::Sender;
+    use tokio::time::Instant;
     use usdt_tests_common::root_command;
-
-    // Duration the thread firing probes waits after receiving a notification.
-    //
-    // This is required to make sure DTrace is "ready" to receive the probe, which takes a bit of time
-    // after the process itself starts.
-    const SLEEP_DURATION: Duration = Duration::from_secs(1);
 
     // Maximum duration to wait for DTrace, controlling total test duration
     const MAX_WAIT: Duration = Duration::from_secs(30);
 
-    fn run_test(recv: Receiver<()>) {
+    // A sentinel printed by DTrace, so we know when it starts up successfully.
+    const BEGIN_SENTINEL: &str = "BEGIN";
+
+    // Fire the test probes in sequence, when a notification is received on the channel.
+    async fn fire_test_probes(mut recv: Receiver<()>) {
         usdt::register_probes().unwrap();
 
         // Wait for notification from the main thread
-        recv.recv().unwrap();
-        sleep(SLEEP_DURATION);
+        println!("Test runner waiting for first notification");
+        recv.recv().await.unwrap();
         println!("Test runner firing first probe");
 
         // Fire the good probe until the main thread signals us to continue.
         let data = ProbeArg::default();
         test_json::good!(|| &data);
-        println!("Test runner awaiting notification");
-        recv.recv().unwrap();
+        println!("Test runner fired first probe");
+        println!("Test runner awaiting notification to continue");
+        recv.recv().await.unwrap();
+        println!("Test runner received notification to continue");
 
         // Fire the bad probe.
-        sleep(SLEEP_DURATION);
         println!("Test runner firing second probe");
         let data = NotJsonSerializable::default();
         test_json::bad!(|| &data);
+        println!("Test runner fired second probe");
     }
 
-    #[test]
-    fn test_json_support() {
-        let (tx, rx) = channel();
-        let test_thread = std::thread::spawn(|| run_test(rx));
+    // Run DTrace as a subprocess, waiting for the JSON output of the provided probe.
+    async fn run_dtrace_and_return_json(tx: &Sender<()>, probe_name: &str) -> Value {
+        // Start the DTrace subprocess, and don't exit if the probe doesn't exist.
+        let mut dtrace = Command::new(root_command())
+            .arg("dtrace")
+            .arg("-Z")
+            .arg("-q")
+            .arg("-n")
+            // The test probe we're interested in listening for.
+            .arg(format!(
+                "test_json{}:::{} {{ printf(\"%s\", copyinstr(arg0)); exit(0); }}",
+                std::process::id(),
+                probe_name
+            ))
+            .arg("-n")
+            // An output printed by DTrace when it starts, to coordinate with the test thread
+            // firing the probe itself.
+            .arg(format!("BEGIN {{ trace(\"{}\"); }}", BEGIN_SENTINEL))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn DTrace subprocess");
 
-        fn run_dtrace_and_return_json(tx: &Sender<()>, probe_name: &str) -> Value {
-            // Start the DTrace subprocess, and don't exit if the probe doesn't exist.
-            let mut dtrace = root_command("dtrace")
-                .arg("-Z")
-                .arg("-q")
-                .arg("-n")
-                .arg(format!(
-                    "test_json{}:::{} {{ printf(\"%s\", copyinstr(arg0)); exit(0); }}",
-                    std::process::id(),
-                    probe_name
-                ))
-                .stdin(Stdio::piped())
-                .stderr(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()
-                .unwrap();
-            // We should now see the probe having fired exactly once. Grab the output data, kill the
-            // DTrace process, and then parse the output as JSON.
-            tx.send(()).unwrap();
+        // Wait for DTrace to correctly start up before notifying the test thread to start
+        // firing probes.
+        let now = Instant::now();
+        wait_for_begin_sentinel(&mut dtrace, &now).await;
 
-            // Wait for the process to finish, up to a pretty generous limit.
-            let now = Instant::now();
-            while matches!(dtrace.try_wait(), Ok(None)) && now.elapsed() < MAX_WAIT {
-                println!("DTrace still running");
-                sleep(SLEEP_DURATION);
+        // We should now see the probe having fired exactly once. Grab the output data, kill the
+        // DTrace process, and then parse the output as JSON.
+        tx.send(()).await.unwrap();
+
+        // Wait for the process to finish, up to a pretty generous limit.
+        let output = tokio::time::timeout_at(now + MAX_WAIT, dtrace.wait_with_output())
+            .await
+            .expect(&format!("DTrace did not complete within {:?}", MAX_WAIT))
+            .expect("Failed to wait for DTrace subprocess");
+        assert!(
+            output.status.success(),
+            "DTrace process failed:\n{:?}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stdout = std::str::from_utf8(&output.stdout).expect("Non-UTF8 stdout");
+        println!("DTrace output\n{}\n", stdout);
+        let json: Value = serde_json::from_str(&stdout).unwrap();
+        json
+    }
+
+    // Check DTrace subprocess stdout for the begin sentinel, telling us the program has spawned
+    // successfully.
+    async fn wait_for_begin_sentinel(dtrace: &mut Child, now: &Instant) {
+        let mut output = String::new();
+        let stdout = dtrace.stdout.as_mut().expect("Expected piped stdout");
+        let max_time = *now + MAX_WAIT;
+
+        // Try to read data from stdout, up to the maximum wait time. This may take multiple reads,
+        // though it's pretty unlikely.
+        while now.elapsed() < MAX_WAIT {
+            let read_task = tokio::time::timeout_at(max_time, async {
+                let mut bytes = vec![0; 128];
+                stdout.read(&mut bytes).await.map(|_| bytes)
+            });
+            let Ok(read_result) = read_task.await else {
+                println!("DTrace not yet ready");
+                continue;
+            };
+            let chunk = read_result.expect("Failed to read DTrace stdout");
+            output.push_str(std::str::from_utf8(&chunk).expect("Non-UTF8 stdout"));
+            if output.contains(BEGIN_SENTINEL) {
+                println!("DTrace started up successfully");
+                return;
             }
-            assert!(
-                now.elapsed() < MAX_WAIT,
-                "DTrace did not complete within {:?}",
-                MAX_WAIT
-            );
-            let output = dtrace.wait_with_output().unwrap();
-            assert!(
-                output.status.success(),
-                "DTrace process failed:\n{}",
-                String::from_utf8(output.stderr).unwrap()
-            );
-            println!("DTrace output\n\n{:#?}", output);
-            let json: Value = serde_json::from_slice(&output.stdout).unwrap();
-            json
         }
+        panic!("DTrace failed to startup within {:?}", MAX_WAIT);
+    }
 
-        let json = run_dtrace_and_return_json(&tx, "good");
+    #[tokio::test]
+    async fn test_json_support() {
+        let (tx, rx) = channel(4);
+        let test_task = tokio::task::spawn(fire_test_probes(rx));
+
+        let json = run_dtrace_and_return_json(&tx, "good").await;
         assert!(json.get("ok").is_some());
         assert!(json.get("err").is_none());
         assert_eq!(json["ok"]["value"], Value::from(1));
         assert_eq!(json["ok"]["buffer"], Value::from(vec![1, 2, 3]));
 
         // Tell the thread to continue with the bad probe
-        let json = run_dtrace_and_return_json(&tx, "bad");
+        let json = run_dtrace_and_return_json(&tx, "bad").await;
         assert!(json.get("ok").is_none());
         assert!(json.get("err").is_some());
         assert_eq!(json["err"], Value::from(SERIALIZATION_ERROR));
 
-        test_thread.join().unwrap();
+        test_task.await.unwrap();
     }
 }

--- a/tests/test-json/src/main.rs
+++ b/tests/test-json/src/main.rs
@@ -169,16 +169,19 @@ mod tests {
                 let mut bytes = vec![0; 128];
                 stdout.read(&mut bytes).await.map(|_| bytes)
             });
-            let Ok(read_result) = read_task.await else {
-                println!("DTrace not yet ready");
-                continue;
-            };
-            let chunk = read_result.expect("Failed to read DTrace stdout");
-            output.push_str(std::str::from_utf8(&chunk).expect("Non-UTF8 stdout"));
-            if output.contains(BEGIN_SENTINEL) {
-                println!("DTrace started up successfully");
-                return;
+            match read_task.await {
+                Ok(read_result) => {
+                    let chunk = read_result.expect("Failed to read DTrace stdout");
+                    output.push_str(std::str::from_utf8(&chunk).expect("Non-UTF8 stdout"));
+                    if output.contains(BEGIN_SENTINEL) {
+                        println!("DTrace started up successfully");
+                        return;
+                    }
+                }
+                _ => {}
             }
+            println!("DTrace not yet ready");
+            continue;
         }
         panic!("DTrace failed to startup within {:?}", MAX_WAIT);
     }

--- a/usdt-tests-common/src/lib.rs
+++ b/usdt-tests-common/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Oxide Computer Company
+// Copyright 2024 Oxide Computer Company
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::process::Command;
-
 #[cfg(target_os = "illumos")]
-pub fn root_command(name: &str) -> Command {
+pub fn root_command() -> String {
     // On illumos systems, we prefer pfexec(1) but allow some other command to
     // be specified through the environment.
-    let pfexec = std::env::var("PFEXEC").unwrap_or_else(|_| "/usr/bin/pfexec".to_string());
-    let mut cmd = Command::new(pfexec);
-    cmd.arg(name);
-    cmd
+    std::env::var("PFEXEC").unwrap_or_else(|_| "/usr/bin/pfexec".to_string())
 }
 
 #[cfg(not(target_os = "illumos"))]
-pub fn root_command(name: &str) -> Command {
-    let mut cmd = Command::new("sudo");
-    cmd.arg(name);
-    cmd
+pub fn root_command() -> String {
+    String::from("sudo")
 }


### PR DESCRIPTION
The tests for JSON output work by starting DTrace as a subprocess; firing some probes in the Rust test code; and then grabbing the DTrace output and verifying its properties. There was a race here: although we waited to fire the probes until requested, we never actually waited for DTrace to correctly start and indicate readiness. Test hangs ensue, at least on macOS where `sudo` actually requires a password in most cases.

This adds synchronization in the other direction, waiting for DTrace to print a sentinel in its BEGIN clause, so that the tests don't start until it has successfully spawned.

Fixes #155