### PR TITLE
Some dependency updates that require manual work

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,12 +142,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-01
+          toolchain: nightly-2022-10-01
           override: true
           profile: minimal
       - run: >
           RUST_BACKTRACE=1
-          cargo +nightly-2022-07-01 test
+          cargo +nightly-2022-10-01 test
           --release
           --verbose
           --workspace
@@ -164,12 +164,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-01
+          toolchain: nightly-2022-10-01
           override: true
           profile: minimal
       - run: >
           RUST_BACKTRACE=1
-          cargo +nightly-2022-07-01 test
+          cargo +nightly-2022-10-01 test
           --release
           --verbose
           --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +186,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -353,7 +362,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -589,7 +598,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -680,6 +689,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "rename"
 version = "0.0.0"
 dependencies = [
@@ -699,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
 dependencies = [
  "futures",
  "futures-timer",
@@ -711,15 +755,18 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
 dependencies = [
  "cfg-if",
+ "glob",
  "proc-macro2",
  "quote",
+ "regex",
+ "relative-path",
  "rustc_version",
- "syn 1.0.109",
+ "syn",
  "unicode-ident",
 ]
 
@@ -767,7 +814,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -793,7 +840,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -816,7 +863,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -882,17 +929,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59bf04c28bee9043ed9ea1e41afc0552288d3aba9c6efdd78903b802926f4879"
@@ -949,7 +985,7 @@ checksum = "3dcf4a824cce0aeacd6f38ae6f24234c8e80d68632338ebaa1443b5df9e29e19"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -989,7 +1025,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]
 
 [[package]]
@@ -1048,7 +1084,7 @@ dependencies = [
  "quote",
  "rstest",
  "serde_tokenstream",
- "syn 2.0.35",
+ "syn",
  "usdt-impl",
 ]
 
@@ -1064,7 +1100,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.35",
+ "syn",
  "thiserror",
  "thread-id",
  "version_check",
@@ -1078,7 +1114,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_tokenstream",
- "syn 2.0.35",
+ "syn",
  "usdt-impl",
 ]
 
@@ -1287,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -1297,11 +1333,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.6"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn",
 ]

--- a/dof/Cargo.toml
+++ b/dof/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 goblin = { version = "0.8", optional = true, features = ["elf64", "mach64"] }
 pretty-hex = { version = "0.4", optional = true }
 thiserror = "1"
-zerocopy = "0.6"
+zerocopy = { version = "0.7.32", features = [ "derive" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 

--- a/dof/src/dof_bindings.rs
+++ b/dof/src/dof_bindings.rs
@@ -3,7 +3,7 @@
 
 #![allow(non_camel_case_types)]
 
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 pub const DIF_VERSION_1: u32 = 1;
 pub const DIF_VERSION_2: u32 = 2;
@@ -277,7 +277,7 @@ pub const DOF_SECF_LOAD: u32 = 1;
 pub const DOF_RELO_NONE: u32 = 0;
 pub const DOF_RELO_SETX: u32 = 1;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dtrace_diftype {
     pub dtdt_kind: u8,
     pub dtdt_ckind: u8,
@@ -287,7 +287,7 @@ pub struct dtrace_diftype {
 }
 pub type dtrace_diftype_t = dtrace_diftype;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_hdr {
     pub dofh_ident: [u8; 16usize],
     pub dofh_flags: u32,
@@ -303,7 +303,7 @@ pub type dof_hdr_t = dof_hdr;
 pub type dof_secidx_t = u32;
 pub type dof_stridx_t = u32;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_sec {
     pub dofs_type: u32,
     pub dofs_align: u32,
@@ -314,7 +314,7 @@ pub struct dof_sec {
 }
 pub type dof_sec_t = dof_sec;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_ecbdesc {
     pub dofe_probes: dof_secidx_t,
     pub dofe_pred: dof_secidx_t,
@@ -324,7 +324,7 @@ pub struct dof_ecbdesc {
 }
 pub type dof_ecbdesc_t = dof_ecbdesc;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_probedesc {
     pub dofp_strtab: dof_secidx_t,
     pub dofp_provider: dof_stridx_t,
@@ -335,7 +335,7 @@ pub struct dof_probedesc {
 }
 pub type dof_probedesc_t = dof_probedesc;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_actdesc {
     pub dofa_difo: dof_secidx_t,
     pub dofa_strtab: dof_secidx_t,
@@ -346,14 +346,14 @@ pub struct dof_actdesc {
 }
 pub type dof_actdesc_t = dof_actdesc;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_difohdr {
     pub dofd_rtype: dtrace_diftype_t,
     pub dofd_links: [dof_secidx_t; 1usize],
 }
 pub type dof_difohdr_t = dof_difohdr;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_relohdr {
     pub dofr_strtab: dof_secidx_t,
     pub dofr_relsec: dof_secidx_t,
@@ -361,7 +361,7 @@ pub struct dof_relohdr {
 }
 pub type dof_relohdr_t = dof_relohdr;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_relodesc {
     pub dofr_name: dof_stridx_t,
     pub dofr_type: u32,
@@ -370,7 +370,7 @@ pub struct dof_relodesc {
 }
 pub type dof_relodesc_t = dof_relodesc;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_optdesc {
     pub dofo_option: u32,
     pub dofo_strtab: dof_secidx_t,
@@ -379,7 +379,7 @@ pub struct dof_optdesc {
 pub type dof_optdesc_t = dof_optdesc;
 pub type dof_attr_t = u32;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_provider {
     pub dofpv_strtab: dof_secidx_t,
     pub dofpv_probes: dof_secidx_t,
@@ -395,7 +395,7 @@ pub struct dof_provider {
 }
 pub type dof_provider_t = dof_provider;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_probe {
     pub dofpr_addr: u64,
     pub dofpr_func: dof_stridx_t,
@@ -414,7 +414,7 @@ pub struct dof_probe {
 }
 pub type dof_probe_t = dof_probe;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_xlator {
     pub dofxl_members: dof_secidx_t,
     pub dofxl_strtab: dof_secidx_t,
@@ -425,7 +425,7 @@ pub struct dof_xlator {
 }
 pub type dof_xlator_t = dof_xlator;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_xlmember {
     pub dofxm_difo: dof_secidx_t,
     pub dofxm_name: dof_stridx_t,
@@ -433,7 +433,7 @@ pub struct dof_xlmember {
 }
 pub type dof_xlmember_t = dof_xlmember;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dof_xlref {
     pub dofxr_xlator: dof_secidx_t,
     pub dofxr_member: u32,
@@ -441,7 +441,7 @@ pub struct dof_xlref {
 }
 pub type dof_xlref_t = dof_xlref;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Copy, Clone)]
 pub struct dof_helper {
     pub dofhp_mod: [::std::os::raw::c_char; 64usize],
     pub dofhp_addr: u64,
@@ -454,7 +454,7 @@ impl Default for dof_helper {
 }
 pub type dof_helper_t = dof_helper;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Copy, Clone)]
 pub struct dof_ioctl_data {
     pub dofiod_count: u64,
     pub dofiod_helpers: [dof_helper_t; 1usize],
@@ -466,7 +466,7 @@ impl Default for dof_ioctl_data {
 }
 pub type dof_ioctl_data_t = dof_ioctl_data;
 #[repr(C)]
-#[derive(AsBytes, FromBytes, Debug, Default, Copy, Clone)]
+#[derive(AsBytes, FromZeroes, FromBytes, Debug, Default, Copy, Clone)]
 pub struct dt_node {
     pub _address: u8,
 }

--- a/dof/src/fmt.rs
+++ b/dof/src/fmt.rs
@@ -18,7 +18,7 @@ use crate::{des::RawSections, Section};
 use crate::{dof_bindings::*, Error};
 use pretty_hex::PrettyHex;
 use std::{fmt::Debug, mem::size_of};
-use zerocopy::{FromBytes, LayoutVerified};
+use zerocopy::{FromBytes, Ref};
 
 /// Format a DOF section into a pretty-printable string.
 pub fn fmt_dof_sec(sec: &dof_sec, index: usize) -> String {
@@ -85,7 +85,7 @@ pub fn fmt_dof_sec_data(sec: &dof_sec, data: &Vec<u8>) -> String {
 fn fmt_dof_sec_type<T: Debug + FromBytes + Copy>(data: &[u8]) -> String {
     data.chunks(size_of::<T>())
         .map(|chunk| {
-            let item = *LayoutVerified::<_, T>::new(chunk).unwrap();
+            let item = *Ref::<_, T>::new(chunk).unwrap();
             format!("{:#x?}", item)
         })
         .collect::<Vec<_>>()

--- a/dtrace-parser/Cargo.toml
+++ b/dtrace-parser/Cargo.toml
@@ -12,4 +12,4 @@ pest_derive = "2.5.7"
 thiserror = "1.0.53"
 
 [dev-dependencies]
-rstest = "0.17.0"
+rstest = "0.18.2"

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -22,4 +22,4 @@ default = ["asm"]
 asm = ["usdt-impl/asm"]
 
 [dev-dependencies]
-rstest = "0.17"
+rstest = "0.18.2"


### PR DESCRIPTION
- Update to `rstest v0.18.2`, which requires another toolchain bump for a transitive dep. We're now at 1.66 for the older nightly tests.
- Update `zerocopy v0.7.32`, which changed public traits