### PR TITLE
Do not rewrite dunders in provider names

### DIFF
--- a/tests/does-it-work/src/main.rs
+++ b/tests/does-it-work/src/main.rs
@@ -18,13 +18,14 @@
 
 #![cfg_attr(usdt_need_feat_asm, feature(asm))]
 #![cfg_attr(usdt_need_feat_asm_sym, feature(asm_sym))]
+#![allow(non_snake_case)]
 
 use usdt::register_probes;
 
 include!(concat!(env!("OUT_DIR"), "/test.rs"));
 
 fn main() {
-    doesit::work!(|| (0, "something"));
+    does__it::work!(|| (0, "something"));
 }
 
 // Dissuade the compiler from inlining this, which would ruin the test for `probefunc`.
@@ -32,7 +33,7 @@ fn main() {
 #[allow(dead_code)]
 fn run_test(rx: std::sync::mpsc::Receiver<()>) {
     register_probes().unwrap();
-    doesit::work!(|| (0, "something"));
+    does__it::work!(|| (0, "something"));
     let _ = rx.recv();
 }
 
@@ -53,7 +54,7 @@ mod tests {
             .arg("-l")
             .arg("-v")
             .arg("-n")
-            .arg("doesit*:::")
+            .arg("does__it*:::")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()
@@ -70,7 +71,7 @@ mod tests {
         println!("{}", output);
 
         // Check the line giving the full description of the probe
-        let mut lines = output.lines().skip_while(|line| !line.contains("doesit"));
+        let mut lines = output.lines().skip_while(|line| !line.contains("does__it"));
         let line = lines
             .next()
             .expect("Expected a line containing the provider name");
@@ -79,7 +80,7 @@ mod tests {
 
         let provider = parts.next().expect("Expected a provider name");
         assert!(
-            provider.starts_with("doesit"),
+            provider.starts_with("does__it"),
             "Provider name appears incorrect: {}",
             provider
         );

--- a/tests/does-it-work/test.d
+++ b/tests/does-it-work/test.d
@@ -1,3 +1,3 @@
-provider doesit {
+provider does__it {
 	probe work(uint8_t, char*);
 };

--- a/usdt-impl/src/record.rs
+++ b/usdt-impl/src/record.rs
@@ -243,7 +243,7 @@ pub(crate) fn emit_probe_record(prov: &str, probe: &str, types: Option<&[DataTyp
         version = PROBE_REC_VERSION,
         n_args = n_args,
         flags = if is_enabled { 1 } else { 0 },
-        prov = prov.replace("__", "-"),
+        prov = prov,
         probe = probe.replace("__", "-"),
         arguments = arguments,
         yeet = if cfg!(target_os = "illumos") {

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -185,8 +185,8 @@
 //!
 //! It's a DTrace convention to name probes with dashes between words, rather than underscores. So
 //! the probe should be `my-probe` rather than `my_probe`. The former is not a valid Rust
-//! identifier, but can be achieved by using _two_ underscores in the provider or probe name. This
-//! crate internally translates `__` into `-` in such cases. For example, the provider:
+//! identifier, but can be achieved by using _two_ underscores in the **probe** name. This crate
+//! internally translates `__` into `-` in such cases. For example, the provider:
 //!
 //! ```ignore
 //! #[usdt::provider("my__provider")]
@@ -195,7 +195,11 @@
 //! }
 //! ```
 //!
-//! will result in a provider and probe name of `my-provider` and `my-probe`.
+//! will result in a provider and probe name of `my__provider` and `my-probe`.
+//! **Important:** This translation of double-underscores to dashes only occurs
+//! in the _probe_ name. Provider names are _not_ modified in any way. This
+//! matches the behavior of existing DTrace implementations, and guarantees that
+//! providers are similarly named regardless of the target platform.
 //!
 //! Examples
 //! --------


### PR DESCRIPTION
- Do not translate `__` to `-` in provider names, only probes. This matches the names one gets when using traditional C tools to generate providers and probes, and guarantees we have the same probe names on macOS (where we have linker support) and other supported platforms.
- Make simple does-it-work test use `__` in the provider name to check new behavior
- Fixes #137