### PR TITLE
Move to memmap2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,13 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1123,7 +1122,7 @@ dependencies = [
  "dof",
  "dtrace-parser",
  "goblin",
- "memmap",
+ "memmap2",
  "serde",
  "usdt-attr-macro",
  "usdt-impl",

--- a/dof/src/fmt.rs
+++ b/dof/src/fmt.rs
@@ -116,7 +116,7 @@ pub fn fmt_dof(sections: Vec<Section>, format: FormatMode) -> Result<Option<Stri
         FormatMode::Raw { include_sections } => {
             for section in sections.iter() {
                 let RawSections { header, sections } =
-                    crate::des::deserialize_raw_sections(&section.as_bytes().as_slice())?;
+                    crate::des::deserialize_raw_sections(section.as_bytes().as_slice())?;
                 out.push_str(&format!("{:#?}\n", header));
                 for (index, (section_header, data)) in sections.into_iter().enumerate() {
                     out.push_str(&format!("{}\n", fmt_dof_sec(&section_header, index)));

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -24,7 +24,7 @@ usdt-macro = { path = "../usdt-macro", default-features = false, version = "=0.5
 usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false, version = "=0.5.0" }
 dof = { path = "../dof", features = ["des"], version = "=0.3.0" }
 goblin = { version = "0.8", features = ["elf32", "elf64"] }
-memmap = { version = "0.7" }
+memmap2 = { version = "0.9.4" }
 
 [features]
 default = ["asm"]

--- a/usdt/src/lib.rs
+++ b/usdt/src/lib.rs
@@ -354,7 +354,7 @@
 
 use dof::{extract_dof_sections, Section};
 use goblin::Object;
-use memmap::{Mmap, MmapOptions};
+use memmap2::{Mmap, MmapOptions};
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::{env, fs};
@@ -454,7 +454,7 @@ pub fn probe_records<P: AsRef<Path>>(path: P) -> Result<Vec<Section>, Error> {
     // Extract DOF section data, which is applicable for an object file built using this crate on
     // macOS, or generally using the platform's dtrace tool, i.e., `dtrace -G` and compiler.
     let dof_sections = extract_dof_sections(&path).map_err(|_| Error::InvalidFile)?;
-    if dof_sections.len() > 0 {
+    if !dof_sections.is_empty() {
         return Ok(dof_sections);
     }
 


### PR DESCRIPTION
The original `memmap` crate has been unmaintained for a while now. This switches to the API-compatible `memmap2` crate. Closes #227.