### PR TITLE
[meta] update pinned toolchain to Rust 1.80

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,8 +58,7 @@ jobs:
           cargo +${{ matrix.toolchain }} test
           --release
           --verbose
-          --workspace
-          --test compile-errors
+          --package compile-errors
 
   stable-test-no-support:
     name: Test on DTrace-less systems

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,6 +58,7 @@ jobs:
           cargo +${{ matrix.toolchain }} test
           --release
           --verbose
+          --workspace
           --test compile-errors
 
   stable-test-no-support:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
 
 env:
   RUST_BACKTRACE: 1
@@ -26,9 +26,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest"]
+        os: [ "macos-latest" ]
         # Test on MSRV and stable.
-        toolchain: ["1.75.0", "stable"]
+        toolchain: [ "1.75.0", "stable" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -46,9 +46,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest"]
+        os: [ "macos-latest" ]
         # Test on the pinned rust-toolchain version.
-        toolchain: ["1.80.0"]
+        toolchain: [ "1.80.0" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -65,9 +65,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: [ "ubuntu-latest", "windows-latest" ]
         # Test on MSRV and stable.
-        toolchain: ["1.75.0", "stable"]
+        toolchain: [ "1.75.0", "stable" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest"]
+        os: [ "macos-latest" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest"]
+        os: [ "macos-latest" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: [ "ubuntu-latest", "windows-latest" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   RUST_BACKTRACE: 1
@@ -17,40 +17,64 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: 1.80.0
           components: rustfmt
       - run: cargo fmt -- --check
 
   stable-test:
-    name: Run all tests
+    name: Run most tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-latest" ]
+        os: ["macos-latest"]
+        # Test on MSRV and stable.
+        toolchain: ["1.75.0", "stable"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: ${{ matrix.toolchain }}
       - run: >
-          cargo test
+          cargo +${{ matrix.toolchain }} test
           --release
           --verbose
           --workspace
+          --exclude compile-errors
+
+  trybuild-test:
+    name: Run trybuild tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["macos-latest"]
+        # Test on the pinned rust-toolchain version.
+        toolchain: ["1.80.0"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - run: >
+          cargo +${{ matrix.toolchain }} test
+          --release
+          --verbose
+          --test compile-errors
 
   stable-test-no-support:
     name: Test on DTrace-less systems
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "windows-latest" ]
+        os: ["ubuntu-latest", "windows-latest"]
+        # Test on MSRV and stable.
+        toolchain: ["1.75.0", "stable"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: ${{ matrix.toolchain }}
       - run: >
-          cargo test
+          cargo +${{ matrix.toolchain }} test
           --release
           --verbose
           --workspace
@@ -64,14 +88,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-latest" ]
+        os: ["macos-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: stable
       - run: >
-          cargo test
+          cargo +stable test
           --release
           --verbose
           --no-default-features
@@ -79,13 +103,14 @@ jobs:
           --exclude does-it-work
           --exclude test-json
           --exclude test-unique-id
+          --exclude compile-errors
 
   recent-nightly:
     name: Run tests on a recent nightly
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-latest" ]
+        os: ["macos-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -104,7 +129,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "windows-latest" ]
+        os: ["ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,9 @@
 [toolchain]
+# The Rust version is pinned because the repo has a number of trybuild tests,
+# and rustc's human-readable output is unstable across Rust versions. This
+# doesn't have to be the MSRV.
+#
 # NOTE: This toolchain is also specified within .github/workflows/rust.yml
 # If you update it here, update that file too.
-channel = "1.75.0"
+channel = "1.80.0"
 profile = "default"

--- a/tests/argument-types/src/main.rs
+++ b/tests/argument-types/src/main.rs
@@ -25,6 +25,7 @@ struct Arg {
 
 /// Types with references are not supported.
 #[derive(Serialize)]
+#[allow(dead_code)]
 struct NotSupported<'a> {
     x: &'a [i32],
 }

--- a/usdt-impl/build.rs
+++ b/usdt-impl/build.rs
@@ -27,6 +27,9 @@ enum Backend {
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-check-cfg=cfg(usdt_backend_noop)");
+    println!("cargo:rustc-check-cfg=cfg(usdt_backend_linker)");
+    println!("cargo:rustc-check-cfg=cfg(usdt_backend_standard)");
 
     let backend = match env::var("CARGO_CFG_TARGET_OS").ok().as_deref() {
         Some("macos") => Backend::Linker,

--- a/usdt-impl/src/lib.rs
+++ b/usdt-impl/src/lib.rs
@@ -263,7 +263,7 @@ where
 }
 
 thread_local! {
-    static CURRENT_ID: RefCell<u32> = RefCell::new(0);
+    static CURRENT_ID: RefCell<u32> = const { RefCell::new(0) };
     static THREAD_ID: RefCell<usize> = RefCell::new(thread_id::get());
 }
 


### PR DESCRIPTION
Also improved CI to ensure that we test on the MSRV and on the latest stable release.

With this we run:

* most tests on MSRV + stable
* trybuild tests on the pinned version

ensuring good coverage across our supported matrix.

Supersedes (and includes) https://github.com/oxidecomputer/usdt/pull/268.