### PR TITLE
fix: add "R" GNU_SHF_RETAIN to stapsdt.rs .stapsdt.base section

### DIFF
--- a/tests/does-it-work/src/main.rs
+++ b/tests/does-it-work/src/main.rs
@@ -146,7 +146,7 @@ mod tests {
             //   stapsdt              0x00000034       NT_STAPSDT (SystemTap probe descriptors)
             //     Provider: does__it
             //     Name: work
-            //     Location: 0x00000000000618b4, Base: 0x0000000000000000, Semaphore: 0x000000000011ccc8
+            //     Location: 0x00000000000618b4, Base: 0x00000000000332b4, Semaphore: 0x000000000011ccc8
             //     Arguments: 1@%dil 8@%rsi
             // ```
             let (send, recv) = channel();
@@ -208,7 +208,7 @@ mod tests {
                 location_address.starts_with("0x")
                     && location_address.ends_with(",")
                     && usize::from_str_radix(&location_address[2..location_address.len() - 1], 16)
-                        .is_ok(),
+                        .is_ok_and(|addr| addr != 0),
                 "Location address appears incorrect: {}",
                 location_address
             );
@@ -222,7 +222,8 @@ mod tests {
             assert!(
                 base_address.starts_with("0x")
                     && base_address.ends_with(",")
-                    && usize::from_str_radix(&base_address[2..base_address.len() - 1], 16).is_ok(),
+                    && usize::from_str_radix(&base_address[2..base_address.len() - 1], 16)
+                        .is_ok_and(|addr| addr != 0),
                 "Base address appears incorrect: {}",
                 base_address
             );
@@ -235,7 +236,8 @@ mod tests {
             let semaphore_address = parts.next().expect("Expected a semaphore address");
             assert!(
                 semaphore_address.starts_with("0x")
-                    && usize::from_str_radix(&semaphore_address[2..], 16).is_ok(),
+                    && usize::from_str_radix(&semaphore_address[2..], 16)
+                        .is_ok_and(|addr| addr != 0),
                 "Semaphore address appears incorrect: {}",
                 semaphore_address
             );

--- a/usdt-impl/src/linker.rs
+++ b/usdt-impl/src/linker.rs
@@ -25,7 +25,7 @@
 //!
 //! In rust, we'll want the probe site to look something like this:
 //! ```ignore
-//! extern "C" {
+//! unsafe extern "C" {
 //!     #[link_name = "__dtrace_stability$foo$v1$1_1_0_1_1_0_1_1_0_1_1_0_1_1_0"]
 //!     fn stability();
 //!     #[link_name = "__dtrace_probe$foo$bar$v1"]
@@ -181,7 +181,7 @@ fn compile_probe(
     compile_error!("USDT only supports x86_64 and AArch64 architectures");
 
     let impl_block = quote! {
-        extern "C" {
+        unsafe extern "C" {
             #[allow(unused)]
             #[link_name = #stability]
             fn stability();

--- a/usdt-impl/src/no-linker.rs
+++ b/usdt-impl/src/no-linker.rs
@@ -119,7 +119,7 @@ fn compile_probe(
 }
 
 fn extract_probe_records_from_section() -> Result<Section, crate::Error> {
-    extern "C" {
+    unsafe extern "C" {
         #[link_name = "__start_set_dtrace_probes"]
         static dtrace_probes_start: usize;
         #[link_name = "__stop_set_dtrace_probes"]

--- a/usdt-impl/src/stapsdt.rs
+++ b/usdt-impl/src/stapsdt.rs
@@ -207,7 +207,7 @@ fn compile_probe(
     let sema_name = format_ident!("__usdt_sema_{}_{}", provider.name, probe.name);
     let impl_block = quote! {
         {
-            extern "C" {
+            unsafe extern "C" {
                 // Note: C libraries use a struct containing an unsigned short
                 // for the semaphore counter. Using just a u16 here directly
                 // offers the slightest risk that on some platforms the struct

--- a/usdt-impl/src/stapsdt.rs
+++ b/usdt-impl/src/stapsdt.rs
@@ -172,7 +172,7 @@ fn emit_probe_record(prov: &str, probe: &str, types: Option<&[DataType]>) -> Str
 // Finally define (if not defined yet) the base used to detect prelink
 // address adjustments.
 .ifndef _.stapsdt.base
-        .pushsection .stapsdt.base, "aG", "progbits", .stapsdt.base, comdat
+        .pushsection .stapsdt.base, "aGR", "progbits", .stapsdt.base, comdat
         .weak _.stapsdt.base
         .hidden _.stapsdt.base
 _.stapsdt.base:


### PR DESCRIPTION
Four days of debugging and discussions came to this: I very much should have noticed that my readelf output had zeroes as the "Base" address which should never be zero ~~unless the semaphore address also is zero~~. This was my linker GC'ing the `_.stapsdt.base` section out of the final executable because it's not being referred to from any allocated section. Programs that unconditionally use this base section ended up doing very bad things to programs being traced, so running `perf stat` to record USDT probes firing would crash the program being traced. Oops! And it turns out this was not just [mold](https://github.com/rui314/mold/issues/1510) linker but also lld and gold; only ld is excempt!

The SystemTap folks are now considering adding the "R" GNU_SHF_RETAIN flag to `sys/sdt.h` so it makes sense to add it here as well. This'll make Linux USDTs work regardless of the linker (well, probably with the exception of wild which just ignores stapsdt notes); tested locally with ld, lld, and mold. CI is running lld for what its worth.

I would have caught this earlier had I included address sanity checks into the STAPSDT readelf output test, so I'm including those here as well. While here, as I was debugging the macro output (for nearly two painful days!) I found a few other things to change: inlining the macro in a 2024 edition crate lead to noncompiling code as a plain `extern "C"` is invalid there and requires `unsafe` in the front (but either is okay in 2021); the output of at least the stapsdt side of the macro was unnecessarily indented. I fixed these two minor pain points.