### PR TITLE
fix: remove invalid cfg requirement for x86_64 in integer_to_asm_op

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "windows-latest" ]
+        os: [ "ubuntu-latest", "windows-latest" ]
         # Test on MSRV and stable.
         toolchain: [ "1.85.0", "stable" ]
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15", "ubuntu-latest" ]
+        os: [ "macos-15", "macos-latest", "ubuntu-latest" ]
         # Test on MSRV and stable.
         toolchain: [ "1.85.0", "stable" ]
     steps:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15", "ubuntu-latest" ]
+        os: [ "macos-15", "macos-latest", "ubuntu-latest" ]
         # Test on the pinned rust-toolchain version.
         toolchain: [ "1.85.0" ]
     steps:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15" ]
+        os: [ "macos-15", "macos-latest" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15", "ubuntu-latest" ]
+        os: [ "macos-15", "macos-latest", "ubuntu-latest" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15", "macos-latest", "ubuntu-latest" ]
+        os: [ "macos-15", "ubuntu-latest" ]
         # Test on MSRV and stable.
         toolchain: [ "1.85.0", "stable" ]
     steps:
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15", "macos-latest", "ubuntu-latest" ]
+        os: [ "macos-15", "ubuntu-24.04-arm", "ubuntu-latest" ]
         # Test on the pinned rust-toolchain version.
         toolchain: [ "1.85.0" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "windows-latest" ]
+        os: [ "windows-latest" ]
         # Test on MSRV and stable.
         toolchain: [ "1.85.0", "stable" ]
     steps:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15", "macos-latest" ]
+        os: [ "macos-15" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -110,7 +110,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "macos-15", "macos-latest", "ubuntu-latest" ]
+        os: [ "macos-15", "ubuntu-latest" ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ "ubuntu-latest", "windows-latest" ]
+        os: [ "windows-latest" ]
         # Test on MSRV and stable.
         toolchain: [ "1.85.0", "stable" ]
     steps:

--- a/tests/does-it-work/src/main.rs
+++ b/tests/does-it-work/src/main.rs
@@ -243,8 +243,15 @@ mod tests {
             // Verify the argument types
             let line = lines.next().expect("Expected a line containing arguments");
             let line = line.trim();
+            let arguments_line = if cfg!(target_arch = "x86_64") {
+                "Arguments: 1@%dil 8@%rsi"
+            } else if cfg!(target_arch = "aarch64") {
+                "Arguments: 1@%w0 8@%x1"
+            } else {
+                unreachable!("Unsupported Linux target architecture")
+            };
             assert_eq!(
-                line, "Arguments: 1@%dil 8@%rsi",
+                line, arguments_line,
                 "Arguments line appears incorrect: {}",
                 line
             );

--- a/tests/does-it-work/src/main.rs
+++ b/tests/does-it-work/src/main.rs
@@ -246,7 +246,7 @@ mod tests {
             let arguments_line = if cfg!(target_arch = "x86_64") {
                 "Arguments: 1@%dil 8@%rsi"
             } else if cfg!(target_arch = "aarch64") {
-                "Arguments: 1@%w0 8@%x1"
+                "Arguments: 1@x0 8@x1"
             } else {
                 unreachable!("Unsupported Linux target architecture")
             };

--- a/usdt-impl/src/stapsdt/args.rs
+++ b/usdt-impl/src/stapsdt/args.rs
@@ -28,7 +28,6 @@ fn integer_to_asm_op(integer: &Integer, reg_index: u8) -> &'static str {
         reg_index <= 5,
         "Up to 6 probe arguments are currently supported"
     );
-    #[cfg(target_arch = "x86_64")]
     if cfg!(target_arch = "x86_64") {
         match (integer.width, reg_index) {
             (BitWidth::Bit8, 0) => "%dil",

--- a/usdt-impl/src/stapsdt/args.rs
+++ b/usdt-impl/src/stapsdt/args.rs
@@ -83,45 +83,15 @@ fn integer_to_asm_op(integer: &Integer, reg_index: u8) -> &'static str {
             _ => unreachable!(),
         }
     } else if cfg!(target_arch = "aarch64") {
-        match (integer.width, reg_index) {
-            (BitWidth::Bit8 | BitWidth::Bit16 | BitWidth::Bit32, 0) => "%w0",
-            (BitWidth::Bit8 | BitWidth::Bit16 | BitWidth::Bit32, 1) => "%w1",
-            (BitWidth::Bit8 | BitWidth::Bit16 | BitWidth::Bit32, 2) => "%w2",
-            (BitWidth::Bit8 | BitWidth::Bit16 | BitWidth::Bit32, 3) => "%w3",
-            (BitWidth::Bit8 | BitWidth::Bit16 | BitWidth::Bit32, 4) => "%w4",
-            (BitWidth::Bit8 | BitWidth::Bit16 | BitWidth::Bit32, 5) => "%w5",
-            (BitWidth::Bit64, 0) => "%x0",
-            (BitWidth::Bit64, 1) => "%x1",
-            (BitWidth::Bit64, 2) => "%x2",
-            (BitWidth::Bit64, 3) => "%x3",
-            (BitWidth::Bit64, 4) => "%x4",
-            (BitWidth::Bit64, 5) => "%x5",
-            #[cfg(target_pointer_width = "32")]
-            (BitWidth::Pointer, 0) => "%w0",
-            #[cfg(target_pointer_width = "64")]
-            (BitWidth::Pointer, 0) => "%x0",
-            #[cfg(target_pointer_width = "32")]
-            (BitWidth::Pointer, 1) => "%w1",
-            #[cfg(target_pointer_width = "64")]
-            (BitWidth::Pointer, 1) => "%x1",
-            #[cfg(target_pointer_width = "32")]
-            (BitWidth::Pointer, 2) => "%w2",
-            #[cfg(target_pointer_width = "64")]
-            (BitWidth::Pointer, 2) => "%x2",
-            #[cfg(target_pointer_width = "32")]
-            (BitWidth::Pointer, 3) => "%w3",
-            #[cfg(target_pointer_width = "64")]
-            (BitWidth::Pointer, 3) => "%x3",
-            #[cfg(target_pointer_width = "32")]
-            (BitWidth::Pointer, 4) => "%w4",
-            #[cfg(target_pointer_width = "64")]
-            (BitWidth::Pointer, 4) => "%x4",
-            #[cfg(target_pointer_width = "32")]
-            (BitWidth::Pointer, 5) => "%w5",
-            #[cfg(target_pointer_width = "64")]
-            (BitWidth::Pointer, 5) => "%x5",
-            #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
-            (BitWidth::Pointer, _) => compile_error!("Unsupported pointer width"),
+        // GNU Assembly syntax for SystemTap only uses the extended register
+        // for some reason.
+        match reg_index {
+            0 => "x0",
+            1 => "x1",
+            2 => "x2",
+            3 => "x3",
+            4 => "x4",
+            5 => "x5",
             _ => unreachable!(),
         }
     } else {

--- a/usdt-impl/src/stapsdt/args.rs
+++ b/usdt-impl/src/stapsdt/args.rs
@@ -125,7 +125,7 @@ fn integer_to_asm_op(integer: &Integer, reg_index: u8) -> &'static str {
             _ => unreachable!(),
         }
     } else {
-        unreachable!()
+        unreachable!("Unsupported Linux target architecture")
     }
 }
 


### PR DESCRIPTION
A mistake I managed to slip in as part of #340: an errant `cfg` (leftovers from a previous version of the code) made the function remove all of its important parts if the machine was not x86_64.

This wasn't caught by CI because none of the CI builds actually run on Arm currently. I added running on macos-latest which are aarch64 machines. 