### PR TITLE
release: 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "dof"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "goblin",
  "pretty-hex",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "dtrace-parser"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "pest",
  "pest_derive",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "dusty"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "dof",
@@ -1100,7 +1100,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "usdt"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dof",
  "goblin",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "usdt-attr-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",
@@ -1126,7 +1126,7 @@ dependencies = [
 
 [[package]]
 name = "usdt-impl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "byteorder",
  "dof",
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "usdt-macro"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dtrace-parser",
  "proc-macro2",

--- a/dof/Cargo.toml
+++ b/dof/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dof"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Tools to read and write the DTrace Object Format (DOF)"

--- a/dtrace-parser/Cargo.toml
+++ b/dtrace-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dtrace-parser"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Parse DTrace provider definitions into Rust"

--- a/dusty/Cargo.toml
+++ b/dusty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dusty"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Tool to inspect USDT probe records in object files"
 license = "Apache-2.0"

--- a/usdt-attr-macro/Cargo.toml
+++ b/usdt-attr-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-attr-macro"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Procedural macro for generating Rust macros for USDT probes"
@@ -10,12 +10,12 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 proc-macro = true
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "=0.2.0" }
+dtrace-parser = { path = "../dtrace-parser", version = "=0.3.0" }
 proc-macro2 = "1"
 serde_tokenstream = "0.2"
 syn = { version = "2", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false, version = "=0.5.0" }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "=0.6.0" }
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/usdt-impl/Cargo.toml
+++ b/usdt-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt-impl"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Main implementation crate for the USDT package"
@@ -8,7 +8,7 @@ repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
 byteorder = "1"
-dtrace-parser = { path = "../dtrace-parser", version = "=0.2.0" }
+dtrace-parser = { path = "../dtrace-parser", version = "=0.3.0" }
 libc = "0.2"
 proc-macro2 = "1"
 quote = "1"
@@ -19,10 +19,10 @@ thiserror = "2"
 thread-id = "5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-dof = { path = "../dof", optional = true, default-features = false, version = "=0.3.0" }
+dof = { path = "../dof", optional = true, default-features = false, version = "=0.4.0" }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-dof = { path = "../dof", default-features = false, version = "=0.3.0" }
+dof = { path = "../dof", default-features = false, version = "=0.4.0" }
 
 [features]
 default = []

--- a/usdt-macro/Cargo.toml
+++ b/usdt-macro/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "usdt-macro"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Procedural macro for generating Rust macros for USDT probes"
 repository = "https://github.com/oxidecomputer/usdt.git"
 
 [dependencies]
-dtrace-parser = { path = "../dtrace-parser", version = "=0.2.0" }
+dtrace-parser = { path = "../dtrace-parser", version = "=0.3.0" }
 proc-macro2 = "1"
 serde_tokenstream = "0.2"
 syn = { version = "2", features = ["full"] }
 quote = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false, version = "=0.5.0" }
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "=0.6.0" }
 
 [lib]
 proc-macro = true

--- a/usdt/Cargo.toml
+++ b/usdt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usdt"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Dust your Rust with USDT probes"
@@ -16,12 +16,12 @@ rust-version = "1.85.0"
 # internal implementation crates.
 [dependencies]
 serde = "1"
-usdt-impl = { path = "../usdt-impl", default-features = false, version = "=0.5.0", features = [
+usdt-impl = { path = "../usdt-impl", default-features = false, version = "=0.6.0", features = [
   "des",
 ] }
-usdt-macro = { path = "../usdt-macro", default-features = false, version = "=0.5.0" }
-usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false, version = "=0.5.0" }
-dof = { path = "../dof", features = ["des"], version = "=0.3.0" }
+usdt-macro = { path = "../usdt-macro", default-features = false, version = "=0.6.0" }
+usdt-attr-macro = { path = "../usdt-attr-macro", default-features = false, version = "=0.6.0" }
+dof = { path = "../dof", features = ["des"], version = "=0.4.0" }
 goblin = { version = "0.10", features = ["elf32", "elf64"] }
 memmap2 = { version = "0.9.8" }
 


### PR DESCRIPTION
Closes #320 (once merged and someone with the bits for it runs `cargo publish`).

This is modeled after the 0.5.0 publish commit, though I did not use `cargo-publish` for it. Tested to [pass](https://github.com/aapoalas/usdt/pull/9).